### PR TITLE
fix: dynamically detect Caddy container name in setup-local-ssl.sh

### DIFF
--- a/scripts/setup-local-ssl.sh
+++ b/scripts/setup-local-ssl.sh
@@ -11,17 +11,30 @@ if [ "$(uname)" != "Darwin" ]; then
     exit 1
 fi
 
-CONTAINER_NAME="balance-tracker-caddy-1"
 CERT_PATH="/data/caddy/pki/authorities/local/root.crt"
 LOCAL_CERT="caddy-root-ca.crt"
 CERT_CN="Caddy Local Authority"
 
+# Dynamically find the Caddy container by its Docker Compose service label.
+# This works regardless of the project name, which varies based on the directory
+# docker compose is run from (e.g. balance-tracker-caddy-1 vs eager-banzai-caddy-1).
+CONTAINER_NAME=$(docker ps \
+    --filter "label=com.docker.compose.service=caddy" \
+    --format "{{.Names}}" | head -1)
+
+if [ -z "$CONTAINER_NAME" ]; then
+    echo "Error: No running Caddy container found."
+    echo "Make sure the containers are running: docker compose up -d"
+    echo "Then wait a few seconds for Caddy to generate its CA."
+    exit 1
+fi
+
+echo "Found Caddy container: $CONTAINER_NAME"
 echo "Extracting Caddy root CA certificate..."
 
 if ! docker cp "${CONTAINER_NAME}:${CERT_PATH}" "${LOCAL_CERT}" 2>/dev/null; then
-    echo "Error: Could not extract certificate."
-    echo "Make sure the containers are running: docker compose up -d"
-    echo "Then wait a few seconds for Caddy to generate its CA."
+    echo "Error: Could not extract certificate from ${CONTAINER_NAME}."
+    echo "Caddy may still be generating its CA — wait a few seconds and try again."
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Removes hardcoded `CONTAINER_NAME="balance-tracker-caddy-1"` from `scripts/setup-local-ssl.sh`
- Docker derives the project name from the working directory, so the container name changes when `docker compose` runs from a worktree (e.g. `eager-banzai-caddy-1` instead of `balance-tracker-caddy-1`)
- Now uses `docker ps --filter "label=com.docker.compose.service=caddy"` to find the Caddy container at runtime, regardless of project name

## Test plan

- [ ] Run `docker compose up` from the main repo directory — `./scripts/setup-local-ssl.sh` finds `balance-tracker-caddy-1`
- [ ] Run `docker compose up` from a worktree directory — script finds the worktree-prefixed container name
- [ ] Confirm `https://localhost` is trusted in the browser after running the script in both contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)