### PR TITLE
feat: Retirement Accounts dashboard

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -43,13 +43,15 @@ CREATE TABLE accounts (
   plaid_item_id INTEGER REFERENCES plaid_items(id),
   institution_name VARCHAR(100) NOT NULL,
   account_name VARCHAR(100) NOT NULL,
-  account_type VARCHAR(50) NOT NULL,  -- 'checking', 'savings', 'credit', 'liability'
+  account_type VARCHAR(50) NOT NULL,  -- 'checking', 'savings', 'credit', 'liability', '401k', 'rrsp', etc.
+  account_category VARCHAR(20) NOT NULL DEFAULT 'liquid', -- 'liquid' | 'retirement'
   currency VARCHAR(3) NOT NULL,        -- 'USD' or 'CAD'
   account_mask VARCHAR(10),            -- Last 4 digits
   plaid_account_id VARCHAR(100) UNIQUE,
   is_liability BOOLEAN DEFAULT false,
   is_active BOOLEAN DEFAULT true,
-  created_at TIMESTAMP DEFAULT NOW()
+  created_at TIMESTAMP DEFAULT NOW(),
+  CONSTRAINT chk_account_category CHECK (account_category IN ('liquid', 'retirement'))
 );
 
 -- Table: balance_snapshots (historical balance data)
@@ -77,6 +79,7 @@ CREATE TABLE exchange_rates (
 CREATE INDEX idx_balance_snapshots_account_date ON balance_snapshots(account_id, date);
 CREATE INDEX idx_accounts_institution ON accounts(institution_name);
 CREATE INDEX idx_accounts_active ON accounts(is_active);
+CREATE INDEX idx_accounts_category ON accounts(account_category);
 CREATE INDEX idx_exchange_rates_currencies ON exchange_rates(from_currency, to_currency);
 
 -- Helper functions for encrypting/decrypting access tokens

--- a/db/seed_sample_data.sql
+++ b/db/seed_sample_data.sql
@@ -12,106 +12,161 @@ INSERT INTO users (username, password_hash) VALUES
 INSERT INTO exchange_rates (from_currency, to_currency, rate, updated_at)
 VALUES ('USD', 'CAD', 1.4400, NOW());
 
--- Institutions (manual accounts, no Plaid tokens)
+-- ─── Institutions ────────────────────────────────────────────────────────────
+-- Liquid / everyday banking
 INSERT INTO plaid_items (institution_name) VALUES
-  ('Maple Bank'),         -- id 1
-  ('Eagle Credit Union'), -- id 2
-  ('Cards Inc');          -- id 3
+  ('Maple Bank'),           -- id 1
+  ('Eagle Credit Union'),   -- id 2
+  ('Cards Inc');            -- id 3
 
--- Accounts
-INSERT INTO accounts (plaid_item_id, institution_name, account_name, account_type, currency, account_mask, is_liability, is_active) VALUES
-  -- Maple Bank (CAD)
-  (1, 'Maple Bank', 'Chequing',        'checking', 'CAD', '7701', false, true),   -- id 1
-  (1, 'Maple Bank', 'High Interest Savings', 'savings', 'CAD', '7702', false, true),   -- id 2
+-- Retirement institutions (manual — no Plaid tokens)
+INSERT INTO plaid_items (institution_name) VALUES
+  ('Summit Investments'),   -- id 4  (USD 401k)
+  ('Northern Pension Trust'), -- id 5  (CAD pension, manual)
+  ('Sun Life Financial');   -- id 6  (CAD RRSP)
 
-  -- Eagle Credit Union (USD)
-  (2, 'Eagle Credit Union', 'US Checking',  'checking', 'USD', '3301', false, true),   -- id 3
-  (2, 'Eagle Credit Union', 'US Savings',   'savings',  'USD', '3302', false, true),   -- id 4
+-- ─── Accounts ────────────────────────────────────────────────────────────────
+INSERT INTO accounts
+  (plaid_item_id, institution_name, account_name, account_type, account_category, currency, account_mask, is_liability, is_active)
+VALUES
+  -- ── Liquid: Maple Bank (CAD) ──────────────────────────────────────────────
+  (1, 'Maple Bank', 'Chequing',             'checking',    'liquid',     'CAD', '7701', false, true),  -- id 1
+  (1, 'Maple Bank', 'High Interest Savings','savings',     'liquid',     'CAD', '7702', false, true),  -- id 2
 
-  -- Credit Cards
-  (3, 'Cards Inc', 'Cashback Visa',    'credit card', 'CAD', '4411', false, true),  -- id 5
-  (3, 'Cards Inc', 'Travel Rewards',   'credit card', 'USD', '4422', false, true),  -- id 6
+  -- ── Liquid: Eagle Credit Union (USD) ──────────────────────────────────────
+  (2, 'Eagle Credit Union', 'US Checking',  'checking',    'liquid',     'USD', '3301', false, true),  -- id 3
+  (2, 'Eagle Credit Union', 'US Savings',   'savings',     'liquid',     'USD', '3302', false, true),  -- id 4
 
-  -- Liabilities (no plaid_item)
-  (NULL, 'Liabilities', 'Mortgage',     'liability', 'CAD', NULL, true, true),  -- id 7
-  (NULL, 'Liabilities', 'Car Loan',     'liability', 'CAD', NULL, true, true),  -- id 8
-  (NULL, 'Liabilities', 'Student Loan', 'liability', 'USD', NULL, true, true);  -- id 9
+  -- ── Liquid: Credit Cards ──────────────────────────────────────────────────
+  (3, 'Cards Inc', 'Cashback Visa',         'credit card', 'liquid',     'CAD', '4411', false, true),  -- id 5
+  (3, 'Cards Inc', 'Travel Rewards',        'credit card', 'liquid',     'USD', '4422', false, true),  -- id 6
 
--- Balance snapshots (~90 days, 6 dates)
--- Patterns:
---   Checking: fluctuates with paycheck/spending cycles
---   Savings: slow upward trend
+  -- ── Liquid: Liabilities ───────────────────────────────────────────────────
+  (NULL, 'Liabilities', 'Mortgage',         'liability',   'liquid',     'CAD', NULL,   true,  true),  -- id 7
+  (NULL, 'Liabilities', 'Car Loan',         'liability',   'liquid',     'CAD', NULL,   true,  true),  -- id 8
+  (NULL, 'Liabilities', 'Student Loan',     'liability',   'liquid',     'USD', NULL,   true,  true),  -- id 9
+
+  -- ── Retirement: Summit Investments 401(k) (USD) ──────────────────────────
+  (4, 'Summit Investments', '401(k)',        '401k',        'retirement', 'USD', '8801', false, true),  -- id 10
+
+  -- ── Retirement: Northern Pension Trust (CAD, manual) ─────────────────────
+  (NULL, 'Northern Pension Trust', 'Public Service Pension', 'pension', 'retirement', 'CAD', NULL, false, true),  -- id 11
+
+  -- ── Retirement: Sun Life RRSP (CAD) ──────────────────────────────────────
+  (6, 'Sun Life Financial', 'Group RRSP',   'rrsp',        'retirement', 'CAD', '9901', false, true);  -- id 12
+
+-- ─── Balance Snapshots ───────────────────────────────────────────────────────
+-- ~90 days of history across 6 snapshot dates.
+--
+-- Liquid accounts:
+--   Checking:    fluctuates with paycheque/spending cycles
+--   Savings:     slow upward trend
 --   Credit cards: negative, spend-then-pay cycles
---   Liabilities: negative, gradual decrease
+--   Liabilities: negative, gradual paydown
+--
+-- Retirement accounts:
+--   401(k) USD:  market-driven growth with minor dips; contributions each period
+--   Pension CAD: steady defined-benefit accumulation
+--   RRSP CAD:    contribution-driven growth, small market variance
 
 -- 2025-12-01
 INSERT INTO balance_snapshots (account_id, balance, date, usd_to_cad_rate) VALUES
-  (1,  4250.00, '2025-12-01', NULL),
-  (2, 15200.00, '2025-12-01', NULL),
-  (3,  1820.50, '2025-12-01', 1.4400),
-  (4,  8500.00, '2025-12-01', 1.4400),
-  (5, -1340.00, '2025-12-01', NULL),
-  (6,  -420.00, '2025-12-01', 1.4400),
+  -- Liquid
+  (1,    4250.00, '2025-12-01', NULL),
+  (2,   15200.00, '2025-12-01', NULL),
+  (3,    1820.50, '2025-12-01', 1.4400),
+  (4,    8500.00, '2025-12-01', 1.4400),
+  (5,   -1340.00, '2025-12-01', NULL),
+  (6,    -420.00, '2025-12-01', 1.4400),
   (7, -385000.00, '2025-12-01', NULL),
-  (8, -18200.00, '2025-12-01', NULL),
-  (9, -32500.00, '2025-12-01', 1.4400);
+  (8,  -18200.00, '2025-12-01', NULL),
+  (9,  -32500.00, '2025-12-01', 1.4400),
+  -- Retirement
+  (10,  141200.00, '2025-12-01', 1.4400),  -- 401(k) USD
+  (11,   79400.00, '2025-12-01', NULL),     -- Pension CAD
+  (12,   43100.00, '2025-12-01', NULL);     -- RRSP CAD
 
--- 2025-12-15 (post-paycheck)
+-- 2025-12-15  (post-paycheque)
 INSERT INTO balance_snapshots (account_id, balance, date, usd_to_cad_rate) VALUES
-  (1,  6800.00, '2025-12-15', NULL),
-  (2, 15350.00, '2025-12-15', NULL),
-  (3,  2950.00, '2025-12-15', 1.4400),
-  (4,  8550.00, '2025-12-15', 1.4400),
-  (5, -2180.00, '2025-12-15', NULL),
-  (6,  -890.00, '2025-12-15', 1.4400),
+  -- Liquid
+  (1,    6800.00, '2025-12-15', NULL),
+  (2,   15350.00, '2025-12-15', NULL),
+  (3,    2950.00, '2025-12-15', 1.4400),
+  (4,    8550.00, '2025-12-15', 1.4400),
+  (5,   -2180.00, '2025-12-15', NULL),
+  (6,    -890.00, '2025-12-15', 1.4400),
   (7, -384500.00, '2025-12-15', NULL),
-  (8, -17950.00, '2025-12-15', NULL),
-  (9, -32300.00, '2025-12-15', 1.4400);
+  (8,  -17950.00, '2025-12-15', NULL),
+  (9,  -32300.00, '2025-12-15', 1.4400),
+  -- Retirement (market dip mid-month, pension steady)
+  (10,  139800.00, '2025-12-15', 1.4400),
+  (11,   79800.00, '2025-12-15', NULL),
+  (12,   43350.00, '2025-12-15', NULL);
 
--- 2026-01-01 (new year, post-holidays spending)
+-- 2026-01-01  (new year, post-holidays spending)
 INSERT INTO balance_snapshots (account_id, balance, date, usd_to_cad_rate) VALUES
-  (1,  3100.00, '2026-01-01', NULL),
-  (2, 15500.00, '2026-01-01', NULL),
-  (3,  1450.00, '2026-01-01', 1.4400),
-  (4,  8600.00, '2026-01-01', 1.4400),
-  (5, -3950.00, '2026-01-01', NULL),
-  (6, -1650.00, '2026-01-01', 1.4400),
+  -- Liquid
+  (1,    3100.00, '2026-01-01', NULL),
+  (2,   15500.00, '2026-01-01', NULL),
+  (3,    1450.00, '2026-01-01', 1.4400),
+  (4,    8600.00, '2026-01-01', 1.4400),
+  (5,   -3950.00, '2026-01-01', NULL),
+  (6,   -1650.00, '2026-01-01', 1.4400),
   (7, -384000.00, '2026-01-01', NULL),
-  (8, -17700.00, '2026-01-01', NULL),
-  (9, -32100.00, '2026-01-01', 1.4400);
+  (8,  -17700.00, '2026-01-01', NULL),
+  (9,  -32100.00, '2026-01-01', 1.4400),
+  -- Retirement (year-end contribution posted; market recovery)
+  (10,  145600.00, '2026-01-01', 1.4400),
+  (11,   80400.00, '2026-01-01', NULL),
+  (12,   44800.00, '2026-01-01', NULL);
 
--- 2026-01-15 (paycheck, paid off holiday cards)
+-- 2026-01-15  (paycheque, paid off holiday cards)
 INSERT INTO balance_snapshots (account_id, balance, date, usd_to_cad_rate) VALUES
-  (1,  7200.00, '2026-01-15', NULL),
-  (2, 15800.00, '2026-01-15', NULL),
-  (3,  3100.00, '2026-01-15', 1.4400),
-  (4,  8700.00, '2026-01-15', 1.4400),
-  (5,  -780.00, '2026-01-15', NULL),
-  (6,  -310.00, '2026-01-15', 1.4400),
+  -- Liquid
+  (1,    7200.00, '2026-01-15', NULL),
+  (2,   15800.00, '2026-01-15', NULL),
+  (3,    3100.00, '2026-01-15', 1.4400),
+  (4,    8700.00, '2026-01-15', 1.4400),
+  (5,    -780.00, '2026-01-15', NULL),
+  (6,    -310.00, '2026-01-15', 1.4400),
   (7, -383500.00, '2026-01-15', NULL),
-  (8, -17450.00, '2026-01-15', NULL),
-  (9, -31900.00, '2026-01-15', 1.4400);
+  (8,  -17450.00, '2026-01-15', NULL),
+  (9,  -31900.00, '2026-01-15', 1.4400),
+  -- Retirement (continued growth)
+  (10,  147300.00, '2026-01-15', 1.4400),
+  (11,   80900.00, '2026-01-15', NULL),
+  (12,   45200.00, '2026-01-15', NULL);
 
 -- 2026-02-01
 INSERT INTO balance_snapshots (account_id, balance, date, usd_to_cad_rate) VALUES
-  (1,  4900.00, '2026-02-01', NULL),
-  (2, 16000.00, '2026-02-01', NULL),
-  (3,  2200.00, '2026-02-01', 1.4400),
-  (4,  8800.00, '2026-02-01', 1.4400),
-  (5, -1560.00, '2026-02-01', NULL),
-  (6,  -540.00, '2026-02-01', 1.4400),
+  -- Liquid
+  (1,    4900.00, '2026-02-01', NULL),
+  (2,   16000.00, '2026-02-01', NULL),
+  (3,    2200.00, '2026-02-01', 1.4400),
+  (4,    8800.00, '2026-02-01', 1.4400),
+  (5,   -1560.00, '2026-02-01', NULL),
+  (6,    -540.00, '2026-02-01', 1.4400),
   (7, -383000.00, '2026-02-01', NULL),
-  (8, -17200.00, '2026-02-01', NULL),
-  (9, -31700.00, '2026-02-01', 1.4400);
+  (8,  -17200.00, '2026-02-01', NULL),
+  (9,  -31700.00, '2026-02-01', 1.4400),
+  -- Retirement (small market pullback on 401k; RRSP contribution)
+  (10,  146100.00, '2026-02-01', 1.4400),
+  (11,   81500.00, '2026-02-01', NULL),
+  (12,   46500.00, '2026-02-01', NULL);
 
--- 2026-02-15 (latest)
+-- 2026-02-15  (latest)
 INSERT INTO balance_snapshots (account_id, balance, date, usd_to_cad_rate) VALUES
-  (1,  7500.00, '2026-02-15', NULL),
-  (2, 16200.00, '2026-02-15', NULL),
-  (3,  3350.00, '2026-02-15', 1.4400),
-  (4,  8900.00, '2026-02-15', 1.4400),
-  (5,  -920.00, '2026-02-15', NULL),
-  (6,  -275.00, '2026-02-15', 1.4400),
+  -- Liquid
+  (1,    7500.00, '2026-02-15', NULL),
+  (2,   16200.00, '2026-02-15', NULL),
+  (3,    3350.00, '2026-02-15', 1.4400),
+  (4,    8900.00, '2026-02-15', 1.4400),
+  (5,    -920.00, '2026-02-15', NULL),
+  (6,    -275.00, '2026-02-15', 1.4400),
   (7, -382500.00, '2026-02-15', NULL),
-  (8, -16950.00, '2026-02-15', NULL),
-  (9, -31500.00, '2026-02-15', 1.4400);
+  (8,  -16950.00, '2026-02-15', NULL),
+  (9,  -31500.00, '2026-02-15', 1.4400),
+  -- Retirement (recovery + employer match posted)
+  (10,  149800.00, '2026-02-15', 1.4400),  -- ~$215,712 CAD
+  (11,   82100.00, '2026-02-15', NULL),     -- CAD
+  (12,   47300.00, '2026-02-15', NULL);     -- CAD

--- a/migrations/010_add_account_category.js
+++ b/migrations/010_add_account_category.js
@@ -1,0 +1,135 @@
+// migrations/010_add_account_category.js
+//
+// Adds `account_category` column to the accounts table, distinguishing
+// liquid/everyday accounts (the main dashboard) from retirement accounts
+// (RRSP, 401k, pension, IRA, etc.).
+//
+// Safe to re-run: checks for the column before applying any changes.
+//
+// Run against any environment:
+//   DATABASE_URL=<url> node migrations/010_add_account_category.js
+//   (or let it pick up DATABASE_URL from .env / environment)
+
+require('dotenv').config();
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+async function migrate() {
+  const client = await pool.connect();
+
+  try {
+    console.log('Starting migration 010: Add account_category to accounts');
+
+    await client.query('BEGIN');
+
+    // ── 1. Add column if missing ───────────────────────────────────────────
+    const columnCheck = await client.query(`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_name = 'accounts' AND column_name = 'account_category'
+    `);
+
+    if (columnCheck.rows.length > 0) {
+      console.log('✅ Column account_category already exists — skipping column add.');
+    } else {
+      await client.query(`
+        ALTER TABLE accounts
+          ADD COLUMN account_category VARCHAR(20) NOT NULL DEFAULT 'liquid'
+      `);
+      console.log("✅ Added account_category column (default: 'liquid')");
+    }
+
+    // ── 2. Add CHECK constraint if missing ────────────────────────────────
+    const constraintCheck = await client.query(`
+      SELECT constraint_name
+      FROM information_schema.table_constraints
+      WHERE table_name = 'accounts' AND constraint_name = 'chk_account_category'
+    `);
+
+    if (constraintCheck.rows.length > 0) {
+      console.log('✅ Constraint chk_account_category already exists — skipping.');
+    } else {
+      await client.query(`
+        ALTER TABLE accounts
+          ADD CONSTRAINT chk_account_category
+          CHECK (account_category IN ('liquid', 'retirement'))
+      `);
+      console.log('✅ Added CHECK constraint on account_category');
+    }
+
+    // ── 3. Add index if missing ───────────────────────────────────────────
+    const indexCheck = await client.query(`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE tablename = 'accounts' AND indexname = 'idx_accounts_category'
+    `);
+
+    if (indexCheck.rows.length > 0) {
+      console.log('✅ Index idx_accounts_category already exists — skipping.');
+    } else {
+      await client.query(`
+        CREATE INDEX idx_accounts_category ON accounts(account_category)
+      `);
+      console.log('✅ Created index idx_accounts_category');
+    }
+
+    // ── 4. Auto-fix existing Plaid accounts whose account_type matches a
+    //       retirement subtype but are still categorized as 'liquid'.
+    //       This corrects accounts imported before auto-classification was added.
+    const retirementTypes = [
+      '401k', '401a', '403b', '457b', '457',
+      'ira', 'roth', 'roth 401k',
+      'pension', 'retirement',
+      'rrsp', 'tfsa', 'lira', 'rrif', 'resp',
+    ];
+    const fixResult = await client.query(`
+      UPDATE accounts
+      SET account_category = 'retirement'
+      WHERE account_category = 'liquid'
+        AND LOWER(account_type) = ANY($1::text[])
+    `, [retirementTypes]);
+    if (fixResult.rowCount > 0) {
+      console.log(`✅ Auto-fixed ${fixResult.rowCount} existing account(s) → 'retirement'`);
+    } else {
+      console.log('✅ No existing accounts needed category correction.');
+    }
+
+    await client.query('COMMIT');
+
+    // ── 5. Verify ─────────────────────────────────────────────────────────
+    const verify = await client.query(`
+      SELECT column_name, data_type, column_default, is_nullable
+      FROM information_schema.columns
+      WHERE table_name = 'accounts' AND column_name = 'account_category'
+    `);
+    console.log('\nColumn details:', verify.rows[0]);
+
+    const counts = await client.query(`
+      SELECT account_category, COUNT(*) as count
+      FROM accounts
+      GROUP BY account_category
+      ORDER BY account_category
+    `);
+    console.log('Current category distribution:');
+    counts.rows.forEach(r => console.log(`  ${r.account_category}: ${r.count} accounts`));
+
+    console.log('\n✅ Migration 010 completed successfully!');
+    console.log('\nNEXT STEPS for each environment (sandbox, prd):');
+    console.log('  1. Run this migration against the target DB before deploying server code.');
+    console.log('  2. Then deploy the updated server.js (which filters by account_category).');
+    console.log('  Note: existing accounts with known retirement subtypes are auto-fixed above.');
+
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error('\n❌ Migration 010 failed:', error);
+    throw error;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+migrate().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "create-user": "node db/create_user.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "migrate:account-19-to-34": "node migrations/007_migrate_account_19_to_34.js",
-    "migrate:account-11-to-35": "node migrations/008_migrate_account_11_to_35.js"
+    "migrate:account-11-to-35": "node migrations/008_migrate_account_11_to_35.js",
+    "db:migrate-category": "node migrations/010_add_account_category.js"
   },
   "author": "",
   "license": "ISC",

--- a/public/connect.html
+++ b/public/connect.html
@@ -18,12 +18,12 @@
             min-height: 100vh;
             padding: 40px 20px;
             display: flex;
-            align-items: center;
+            align-items: flex-start;
             justify-content: center;
         }
 
         .container {
-            max-width: 600px;
+            max-width: 680px;
             width: 100%;
         }
 
@@ -62,6 +62,7 @@
             margin-bottom: 10px;
         }
 
+        /* ── Buttons ─────────────────────────────────────────────────────── */
         button {
             background: #667eea;
             color: white;
@@ -75,15 +76,26 @@
             transition: background 0.2s;
         }
 
-        button:hover {
-            background: #5568d3;
+        button:hover { background: #5568d3; }
+        button:disabled { background: #ccc; cursor: not-allowed; }
+
+        .fix-button {
+            background: #e74c3c;
+            color: white;
+            border: none;
+            padding: 6px 14px;
+            border-radius: 6px;
+            font-size: 0.82rem;
+            font-weight: 600;
+            cursor: pointer;
+            width: auto;
+            transition: background 0.2s;
         }
 
-        button:disabled {
-            background: #ccc;
-            cursor: not-allowed;
-        }
+        .fix-button:hover { background: #c0392b; }
+        .fix-button:disabled { background: #ccc; cursor: not-allowed; }
 
+        /* ── Status messages ─────────────────────────────────────────────── */
         .success {
             background: #d4edda;
             border: 1px solid #c3e6cb;
@@ -94,9 +106,7 @@
             display: none;
         }
 
-        .success.show {
-            display: block;
-        }
+        .success.show { display: block; }
 
         .back-link {
             display: inline-block;
@@ -106,78 +116,180 @@
             font-weight: 500;
         }
 
-        .back-link:hover {
-            text-decoration: underline;
-        }
+        .back-link:hover { text-decoration: underline; }
 
-        .connected-banks {
+        /* ── Section shared styles ───────────────────────────────────────── */
+        .accounts-section {
             margin-top: 30px;
             padding-top: 30px;
             border-top: 1px solid #e0e0e0;
         }
 
-        .connected-banks h3 {
+        .accounts-section h3 {
             color: #2c3e50;
-            margin-bottom: 15px;
-            font-size: 1.2rem;
+            margin-bottom: 4px;
+            font-size: 1.15rem;
         }
 
-        .bank-item {
-            padding: 12px;
-            background: #f8f9fa;
-            border-radius: 8px;
-            margin-bottom: 8px;
+        .section-note {
+            color: #95a5a6;
+            font-size: 0.85rem;
+            margin-bottom: 14px;
+        }
+
+        /* ── Institution rows (collapsible) ──────────────────────────────── */
+        .institution-group {
+            border: 1px solid #e0e0e0;
+            border-radius: 10px;
+            margin-bottom: 10px;
+            overflow: hidden;
+        }
+
+        .institution-header {
             display: flex;
             justify-content: space-between;
             align-items: center;
+            padding: 13px 16px;
+            background: #f8f9fa;
+            cursor: pointer;
+            user-select: none;
+            gap: 10px;
         }
 
-        .bank-name {
-            font-weight: 500;
-            color: #2c3e50;
-        }
+        .institution-header:hover { background: #e9ecef; }
 
-        .account-count {
-            color: #7f8c8d;
-            font-size: 0.9rem;
-        }
-
-        .bank-item-right {
+        .institution-header-left {
             display: flex;
             align-items: center;
             gap: 10px;
+            flex: 1;
+            min-width: 0;
         }
+
+        .institution-name {
+            font-weight: 600;
+            color: #2c3e50;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .institution-header-right {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-shrink: 0;
+        }
+
+        .account-count-badge {
+            color: #7f8c8d;
+            font-size: 0.85rem;
+            white-space: nowrap;
+        }
+
+        .chevron {
+            color: #95a5a6;
+            font-size: 0.75rem;
+            transition: transform 0.25s;
+            flex-shrink: 0;
+        }
+
+        .chevron.open { transform: rotate(180deg); }
 
         .login-required-badge {
             background: #fff3cd;
             border: 1px solid #ffc107;
             color: #856404;
-            font-size: 0.8rem;
-            font-weight: 500;
+            font-size: 0.78rem;
+            font-weight: 600;
             padding: 3px 8px;
+            border-radius: 4px;
+            white-space: nowrap;
+        }
+
+        /* ── Account rows inside an institution ──────────────────────────── */
+        .institution-accounts {
+            border-top: 1px solid #e0e0e0;
+        }
+
+        .institution-accounts.collapsed { display: none; }
+
+        .account-row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 10px 16px;
+            border-bottom: 1px solid #f0f0f0;
+            gap: 10px;
+        }
+
+        .account-row:last-child { border-bottom: none; }
+
+        .account-row-left {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+            min-width: 0;
+        }
+
+        .account-name {
+            font-size: 0.95rem;
+            font-weight: 500;
+            color: #2c3e50;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .account-meta {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            flex-wrap: wrap;
+        }
+
+        /* Type tag — shows Plaid's account subtype (e.g. "checking", "401k") */
+        .type-tag {
+            font-size: 0.72rem;
+            font-weight: 600;
+            padding: 2px 7px;
+            border-radius: 4px;
+            background: #f0f0f0;
+            color: #555;
+            text-transform: lowercase;
+        }
+
+        /* Currency badge */
+        .currency-badge {
+            font-size: 0.72rem;
+            font-weight: 700;
+            padding: 2px 6px;
             border-radius: 4px;
         }
 
-        .fix-button {
-            background: #e74c3c;
-            color: white;
-            border: none;
-            padding: 6px 14px;
-            border-radius: 6px;
-            font-size: 0.85rem;
+        .currency-badge.cad {
+            background: #e8f5e9;
+            color: #2e7d32;
+        }
+
+        .currency-badge.usd {
+            background: #e3f2fd;
+            color: #1565c0;
+        }
+
+        /* Category badge — retirement vs liquid */
+        .category-badge {
+            font-size: 0.72rem;
             font-weight: 600;
-            cursor: pointer;
-            width: auto;
-            transition: background 0.2s;
+            padding: 2px 7px;
+            border-radius: 4px;
+            background: #ede7f6;
+            color: #6a1b9a;
         }
 
-        .fix-button:hover {
-            background: #c0392b;
-        }
-
-        .fix-button:disabled {
-            background: #ccc;
-            cursor: not-allowed;
+        .account-mask {
+            font-size: 0.8rem;
+            color: #95a5a6;
         }
     </style>
 </head>
@@ -204,9 +316,18 @@
 
             <a href="/" class="back-link">← Back to Dashboard</a>
 
-            <div class="connected-banks" id="connectedBanks" style="display: none;">
+            <!-- Plaid-connected institutions -->
+            <div class="accounts-section" id="connectedBanks" style="display: none;">
                 <h3>Connected Banks</h3>
+                <p class="section-note">Accounts synced automatically via Plaid</p>
                 <div id="banksList"></div>
+            </div>
+
+            <!-- Manual accounts (no Plaid connection) -->
+            <div class="accounts-section" id="manualSection" style="display: none;">
+                <h3>Manual Accounts</h3>
+                <p class="section-note">Balances updated manually — not connected via Plaid</p>
+                <div id="manualList"></div>
             </div>
         </div>
     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -622,6 +622,36 @@
                 max-width: 100%;
             }
         }
+
+        .page-tabs {
+            display: flex;
+            gap: 8px;
+            margin-bottom: 30px;
+        }
+
+        .tab-link {
+            padding: 10px 20px;
+            border-radius: 8px;
+            text-decoration: none;
+            font-size: 0.95rem;
+            font-weight: 600;
+            transition: all 0.2s;
+            color: #7f8c8d;
+            background: white;
+            border: 1px solid #e0e0e0;
+            box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+        }
+
+        .tab-link:hover {
+            background: #f0f0f0;
+            color: #2c3e50;
+        }
+
+        .tab-link.active {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border-color: transparent;
+        }
     </style>
 </head>
 <body>
@@ -632,6 +662,11 @@
                 <button class="refresh-btn" id="refreshBtn">🔄 Refresh Balances</button>
             </div>
         </h1>
+
+        <div class="page-tabs">
+            <a href="/index.html" class="tab-link active">💵 Liquid Cash</a>
+            <a href="/retirement.html" class="tab-link">🏦 Retirement</a>
+        </div>
 
         <div class="summary-panel">
             <div class="card primary">

--- a/public/js/connect.js
+++ b/public/js/connect.js
@@ -1,116 +1,219 @@
 let linkHandler = null;
 
 // Load connected banks on page load
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
     loadConnectedBanks();
 });
+
+// ─── Data loading ──────────────────────────────────────────────────────────
 
 async function loadConnectedBanks() {
     try {
         const response = await fetch('/api/accounts');
         const accounts = await response.json();
 
-        if (accounts.length > 0) {
-            // Group by institution, tracking count and error state
-            const grouped = {};
-            accounts.forEach(acc => {
-                if (!grouped[acc.institution_name]) {
-                    grouped[acc.institution_name] = {
-                        count: 0,
-                        login_required: false,
-                        plaid_item_id: acc.plaid_item_id || null,
-                    };
-                }
-                if (acc.is_active) {
-                    grouped[acc.institution_name].count++;
-                }
-                if (acc.login_required) {
-                    grouped[acc.institution_name].login_required = true;
-                }
-            });
+        if (!accounts.length) return;
 
-            // Display connected banks
-            const banksList = document.getElementById('banksList');
-            banksList.innerHTML = '';
+        // Split into Plaid-managed vs manually-tracked
+        const plaidAccounts   = accounts.filter(a => a.is_plaid_connected && a.is_active);
+        const manualAccounts  = accounts.filter(a => !a.is_plaid_connected && a.is_active);
 
-            Object.keys(grouped).forEach(institution => {
-                const info = grouped[institution];
-                const item = document.createElement('div');
-                item.className = 'bank-item';
+        renderPlaidInstitutions(plaidAccounts);
+        renderManualAccounts(manualAccounts);
 
-                if (info.login_required && info.plaid_item_id) {
-                    item.innerHTML = `
-                        <span class="bank-name">${institution}</span>
-                        <div class="bank-item-right">
-                            <span class="login-required-badge">Login required</span>
-                            <button class="fix-button" data-item-id="${info.plaid_item_id}" data-institution="${institution}">Fix connection</button>
-                        </div>
-                    `;
-                } else {
-                    item.innerHTML = `
-                        <span class="bank-name">${institution}</span>
-                        <span class="account-count">${info.count} accounts</span>
-                    `;
-                }
-
-                banksList.appendChild(item);
-            });
-
-            // Attach fix button handlers
-            banksList.querySelectorAll('.fix-button').forEach(btn => {
-                btn.addEventListener('click', () => {
-                    const plaidItemId = btn.dataset.itemId;
-                    const institution = btn.dataset.institution;
-                    initializePlaidUpdateMode(plaidItemId, institution, btn);
-                });
-            });
-
-            document.getElementById('connectedBanks').style.display = 'block';
-        }
     } catch (error) {
         console.error('Error loading connected banks:', error);
     }
 }
 
-// Initialize Plaid Link in update mode for a specific item
+// ─── Plaid institutions ────────────────────────────────────────────────────
+
+function renderPlaidInstitutions(accounts) {
+    if (!accounts.length) return;
+
+    // Group by institution name, preserving server sort order.
+    // Also capture the plaid_item_id for the "Fix connection" button.
+    const groups = new Map();
+    accounts.forEach(acc => {
+        if (!groups.has(acc.institution_name)) {
+            groups.set(acc.institution_name, {
+                plaid_item_id:  acc.plaid_item_id || null,
+                login_required: false,
+                accounts: [],
+            });
+        }
+        const g = groups.get(acc.institution_name);
+        if (acc.login_required) g.login_required = true;
+        g.accounts.push(acc);
+    });
+
+    const list = document.getElementById('banksList');
+    list.innerHTML = '';
+
+    groups.forEach((info, institution) => {
+        list.appendChild(buildInstitutionGroup(institution, info));
+    });
+
+    document.getElementById('connectedBanks').style.display = 'block';
+}
+
+// ─── Manual accounts ───────────────────────────────────────────────────────
+
+function renderManualAccounts(accounts) {
+    if (!accounts.length) return;
+
+    // Group by institution name (manual accounts can share an institution label)
+    const groups = new Map();
+    accounts.forEach(acc => {
+        if (!groups.has(acc.institution_name)) {
+            groups.set(acc.institution_name, {
+                plaid_item_id:  null,
+                login_required: false,
+                accounts: [],
+            });
+        }
+        groups.get(acc.institution_name).accounts.push(acc);
+    });
+
+    const list = document.getElementById('manualList');
+    list.innerHTML = '';
+
+    groups.forEach((info, institution) => {
+        list.appendChild(buildInstitutionGroup(institution, info));
+    });
+
+    document.getElementById('manualSection').style.display = 'block';
+}
+
+// ─── DOM builders ──────────────────────────────────────────────────────────
+
+/**
+ * Builds a collapsible institution group containing its account rows.
+ * Works for both Plaid and manual institutions.
+ */
+function buildInstitutionGroup(institutionName, info) {
+    const group = document.createElement('div');
+    group.className = 'institution-group';
+
+    // ── Header ──────────────────────────────────────────────────────────
+    const header = document.createElement('div');
+    header.className = 'institution-header';
+
+    const countLabel = `${info.accounts.length} account${info.accounts.length !== 1 ? 's' : ''}`;
+    const chevronId  = `chevron-${institutionName.replace(/\s+/g, '-')}`;
+
+    header.innerHTML = `
+        <div class="institution-header-left">
+            <span class="institution-name">${institutionName}</span>
+        </div>
+        <div class="institution-header-right">
+            ${info.login_required
+                ? '<span class="login-required-badge">Login required</span>'
+                : `<span class="account-count-badge">${countLabel}</span>`}
+            ${info.login_required && info.plaid_item_id
+                ? `<button class="fix-button"
+                       data-item-id="${info.plaid_item_id}"
+                       data-institution="${institutionName}">Fix connection</button>`
+                : ''}
+            <span class="chevron" id="${chevronId}">▼</span>
+        </div>
+    `;
+
+    // Toggle expansion on header click (but not on the fix button)
+    header.addEventListener('click', e => {
+        if (e.target.classList.contains('fix-button')) return;
+        const body    = group.querySelector('.institution-accounts');
+        const chevron = group.querySelector('.chevron');
+        const isOpen  = !body.classList.contains('collapsed');
+        body.classList.toggle('collapsed', isOpen);
+        chevron.classList.toggle('open', !isOpen);
+    });
+
+    // ── Fix-connection button handler ────────────────────────────────────
+    const fixBtn = header.querySelector('.fix-button');
+    if (fixBtn) {
+        fixBtn.addEventListener('click', () => {
+            initializePlaidUpdateMode(fixBtn.dataset.itemId, fixBtn.dataset.institution, fixBtn);
+        });
+    }
+
+    // ── Account rows ─────────────────────────────────────────────────────
+    const body = document.createElement('div');
+    body.className = 'institution-accounts'; // open by default
+
+    info.accounts.forEach(acc => {
+        body.appendChild(buildAccountRow(acc));
+    });
+
+    group.appendChild(header);
+    group.appendChild(body);
+    return group;
+}
+
+/**
+ * Builds a single account row showing name, type, currency, category, and mask.
+ */
+function buildAccountRow(acc) {
+    const row = document.createElement('div');
+    row.className = 'account-row';
+
+    const currencyClass = acc.currency === 'CAD' ? 'cad' : 'usd';
+    const maskHtml = acc.account_mask
+        ? `<span class="account-mask">····${acc.account_mask}</span>`
+        : '';
+    const categoryHtml = acc.account_category === 'retirement'
+        ? '<span class="category-badge">Retirement</span>'
+        : '';
+
+    row.innerHTML = `
+        <div class="account-row-left">
+            <span class="account-name">${acc.account_name}</span>
+            <div class="account-meta">
+                <span class="type-tag">${acc.account_type}</span>
+                <span class="currency-badge ${currencyClass}">${acc.currency}</span>
+                ${categoryHtml}
+                ${maskHtml}
+            </div>
+        </div>
+    `;
+
+    return row;
+}
+
+// ─── Plaid update mode ─────────────────────────────────────────────────────
+
 async function initializePlaidUpdateMode(plaidItemId, institution, btn) {
-    btn.disabled = true;
+    btn.disabled  = true;
     btn.textContent = 'Loading...';
 
     try {
         const response = await fetch('/api/create_link_token_update', {
-            method: 'POST',
+            method:  'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ plaid_item_id: plaidItemId }),
+            body:    JSON.stringify({ plaid_item_id: plaidItemId }),
         });
 
         const data = await response.json();
-        if (!response.ok) {
-            throw new Error(data.error || 'Failed to create update token');
-        }
+        if (!response.ok) throw new Error(data.error || 'Failed to create update token');
 
         const handler = Plaid.create({
             token: data.link_token,
             onSuccess: async (_public_token, _metadata) => {
-                // In update mode the item is restored automatically — just clear the flag
                 await fetch('/api/clear_item_error', {
-                    method: 'POST',
+                    method:  'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ plaid_item_id: plaidItemId }),
+                    body:    JSON.stringify({ plaid_item_id: plaidItemId }),
                 });
 
-                document.getElementById('successMessage').innerHTML =
-                    `<strong>✅ ${institution} reconnected successfully!</strong><br>Your connection has been restored.`;
-                document.getElementById('successMessage').classList.add('show');
+                const msg = document.getElementById('successMessage');
+                msg.innerHTML = `<strong>✅ ${institution} reconnected successfully!</strong><br>Your connection has been restored.`;
+                msg.classList.add('show');
 
-                // Reload the banks list to remove the error state
                 loadConnectedBanks();
             },
-            onExit: (err, _metadata) => {
-                if (err != null) {
-                    console.error('Link exit with error:', err);
-                }
-                btn.disabled = false;
+            onExit: (err) => {
+                if (err != null) console.error('Link exit with error:', err);
+                btn.disabled    = false;
                 btn.textContent = 'Fix connection';
             },
         });
@@ -119,56 +222,46 @@ async function initializePlaidUpdateMode(plaidItemId, institution, btn) {
     } catch (error) {
         console.error('Error initializing update mode:', error);
         alert('Error: ' + error.message);
-        btn.disabled = false;
+        btn.disabled    = false;
         btn.textContent = 'Fix connection';
     }
 }
 
-// Initialize Plaid Link
+// ─── Plaid Link (new connection) ───────────────────────────────────────────
+
 async function initializePlaidLink() {
     try {
-        const response = await fetch('/api/create_link_token', {
-            method: 'POST',
-        });
-
-        const data = await response.json();
+        const response = await fetch('/api/create_link_token', { method: 'POST' });
+        const data     = await response.json();
 
         linkHandler = Plaid.create({
             token: data.link_token,
-            onSuccess: async (public_token, metadata) => {
-                console.log('Link success!', metadata);
+            onSuccess: async (public_token) => {
+                const linkBtn = document.getElementById('linkButton');
+                linkBtn.disabled    = true;
+                linkBtn.textContent = 'Connecting...';
 
-                // Show loading state
-                document.getElementById('linkButton').disabled = true;
-                document.getElementById('linkButton').textContent = 'Connecting...';
-
-                // Exchange public token for access token
                 const exchangeResponse = await fetch('/api/exchange_public_token', {
-                    method: 'POST',
+                    method:  'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ public_token }),
+                    body:    JSON.stringify({ public_token }),
                 });
 
                 if (exchangeResponse.ok) {
-                    // Show success message
-                    document.getElementById('successMessage').innerHTML =
-                        '<strong>✅ Bank connected successfully!</strong><br>Your accounts have been added to the database.';
-                    document.getElementById('successMessage').classList.add('show');
-                    document.getElementById('linkButton').textContent = 'Connect Another Bank';
-                    document.getElementById('linkButton').disabled = false;
-
-                    // Reload connected banks list
+                    const msg = document.getElementById('successMessage');
+                    msg.innerHTML = '<strong>✅ Bank connected successfully!</strong><br>Your accounts have been added to the database.';
+                    msg.classList.add('show');
+                    linkBtn.textContent = 'Connect Another Bank';
+                    linkBtn.disabled    = false;
                     loadConnectedBanks();
                 } else {
                     alert('Error connecting bank. Please try again.');
-                    document.getElementById('linkButton').disabled = false;
-                    document.getElementById('linkButton').textContent = 'Connect Bank Account';
+                    linkBtn.disabled    = false;
+                    linkBtn.textContent = 'Connect Bank Account';
                 }
             },
-            onExit: (err, metadata) => {
-                if (err != null) {
-                    console.error('Link exit with error:', err);
-                }
+            onExit: (err) => {
+                if (err != null) console.error('Link exit with error:', err);
                 document.getElementById('linkButton').disabled = false;
             },
         });
@@ -178,7 +271,6 @@ async function initializePlaidLink() {
     }
 }
 
-// Connect button click handler
 document.getElementById('linkButton').addEventListener('click', () => {
     if (linkHandler) {
         linkHandler.open();

--- a/public/js/retirement.js
+++ b/public/js/retirement.js
@@ -1,0 +1,400 @@
+// retirement.js — Retirement accounts dashboard
+
+// ─── Auth guard ────────────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', function () {
+    fetch('/api/check-auth')
+        .then(r => r.json())
+        .then(data => {
+            if (!data.authenticated) {
+                window.location.href = '/login.html';
+            } else {
+                loadRetirementDashboard();
+            }
+        })
+        .catch(() => {
+            window.location.href = '/login.html';
+        });
+});
+
+// ─── Constants ─────────────────────────────────────────────────────────────
+
+// Human-readable labels for each supported retirement account type.
+const RETIREMENT_TYPE_LABELS = {
+    '401k':       '401(k)',
+    '401a':       '401(a)',
+    '403b':       '403(b)',
+    '457b':       '457(b)',
+    'ira':        'IRA',
+    'roth':       'Roth IRA',   // Plaid subtype for Roth IRA
+    'roth_ira':   'Roth IRA',   // alias used in seed data / manual accounts
+    'roth 401k':  'Roth 401(k)',
+    'rrsp':       'RRSP',
+    'tfsa':       'TFSA',
+    'lira':       'LIRA',
+    'rrif':       'RRIF',
+    'resp':       'RESP',
+    'pension':    'Pension',
+    'retirement': 'Retirement',
+};
+
+// CSS class suffix applied to account-type tag badges.
+const RETIREMENT_TYPE_TAG_CLASS = {
+    '401k':       'tag-401k',
+    '401a':       'tag-401k',
+    '403b':       'tag-401k',
+    '457b':       'tag-401k',
+    'ira':        'tag-ira',
+    'roth':       'tag-ira',
+    'roth_ira':   'tag-ira',
+    'roth 401k':  'tag-ira',
+    'rrsp':       'tag-rrsp',
+    'tfsa':       'tag-tfsa',
+    'lira':       'tag-lira',
+    'rrif':       'tag-lira',
+    'resp':       'tag-tfsa',
+    'pension':    'tag-pension',
+    'retirement': 'tag-pension',
+};
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function formatCAD(amount) {
+    return new Intl.NumberFormat('en-CA', {
+        style: 'currency',
+        currency: 'CAD',
+        minimumFractionDigits: 2,
+    }).format(amount);
+}
+
+function formatNative(amount, currency) {
+    return new Intl.NumberFormat('en-CA', {
+        style: 'currency',
+        currency: currency,
+        minimumFractionDigits: 2,
+    }).format(amount);
+}
+
+function formatDate(dateStr) {
+    if (!dateStr) return '—';
+    const [y, m, d] = dateStr.split('-').map(Number);
+    return new Date(y, m - 1, d).toLocaleDateString('en-CA', {
+        year: 'numeric', month: 'short', day: 'numeric',
+    });
+}
+
+function typeLabel(accountType) {
+    return RETIREMENT_TYPE_LABELS[accountType] || accountType.toUpperCase();
+}
+
+function typeTagClass(accountType) {
+    return RETIREMENT_TYPE_TAG_CLASS[accountType] || 'tag-other';
+}
+
+// ─── Data loading ──────────────────────────────────────────────────────────
+
+async function loadRetirementDashboard() {
+    try {
+        const [summaryData, balancesData] = await Promise.all([
+            fetch('/api/retirement_summary').then(r => {
+                if (!r.ok) throw new Error('retirement_summary failed');
+                return r.json();
+            }),
+            fetch('/api/retirement_balances').then(r => {
+                if (!r.ok) throw new Error('retirement_balances failed');
+                return r.json();
+            }),
+        ]);
+
+        renderSummaryCards(summaryData);
+        renderAccountBalances(balancesData);
+        await renderTrendChart('90d');
+        setupChartButtons();
+    } catch (error) {
+        console.error('Error loading retirement dashboard:', error);
+        document.getElementById('summaryPanel').innerHTML =
+            '<p style="color:#e74c3c;padding:20px;">Failed to load retirement data. Please refresh the page.</p>';
+    }
+}
+
+// ─── Summary cards ─────────────────────────────────────────────────────────
+
+function renderSummaryCards(data) {
+    const panel = document.getElementById('summaryPanel');
+    panel.innerHTML = '';
+
+    const rateNote = data.usdToCadRate
+        ? ` · USD/CAD ${parseFloat(data.usdToCadRate).toFixed(4)}`
+        : '';
+    const dateNote = data.date ? `as of ${formatDate(data.date)}` : 'no data yet';
+
+    // Primary card — grand total
+    const primary = document.createElement('div');
+    primary.className = 'card primary';
+    primary.innerHTML = `
+        <div class="card-label">Total Retirement (CAD)</div>
+        <div class="card-value">${formatCAD(data.totalRetirementCad || 0)}</div>
+        <div class="card-sub">${dateNote}${rateNote}</div>
+    `;
+    panel.appendChild(primary);
+
+    // One card per account type that has a non-zero balance
+    (data.byType || []).forEach(type => {
+        const label = typeLabel(type.accountType);
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.innerHTML = `
+            <div class="card-label">${label}</div>
+            <div class="card-value type-positive">${formatCAD(type.totalCad)}</div>
+            <div class="card-sub">${type.accountCount} account${type.accountCount !== 1 ? 's' : ''}</div>
+        `;
+        panel.appendChild(card);
+    });
+
+    // Update the balances panel header date
+    const balancesHeading = document.querySelector('.balances-panel h2 span');
+    if (balancesHeading) {
+        balancesHeading.textContent = data.date ? 'as of ' + formatDate(data.date) : '';
+    }
+}
+
+// ─── Account list ──────────────────────────────────────────────────────────
+
+function renderAccountBalances(data) {
+    const panel = document.querySelector('.balances-panel');
+
+    // Remove any previously rendered institution sections
+    panel.querySelectorAll('.institution').forEach(el => el.remove());
+
+    if (!data.accounts || data.accounts.length === 0) {
+        const msg = document.createElement('p');
+        msg.style.cssText = 'color:#7f8c8d;padding:20px 0;';
+        msg.textContent = 'No retirement accounts found. Add accounts to get started.';
+        panel.appendChild(msg);
+        return;
+    }
+
+    // Group accounts by institution, preserving server sort order
+    const byInstitution = new Map();
+    data.accounts.forEach(account => {
+        if (!byInstitution.has(account.institution_name)) {
+            byInstitution.set(account.institution_name, []);
+        }
+        byInstitution.get(account.institution_name).push(account);
+    });
+
+    byInstitution.forEach((accounts, institutionName) => {
+        const section = document.createElement('div');
+        section.className = 'institution';
+
+        const header = document.createElement('div');
+        header.className = 'institution-header';
+        header.onclick = function () { toggleInstitution(this); };
+        header.innerHTML = `<span>${institutionName}</span><span class="chevron">▼</span>`;
+
+        const accountsDiv = document.createElement('div');
+        accountsDiv.className = 'institution-accounts';
+
+        accounts.forEach(account => {
+            const balance = parseFloat(account.balance);
+            const rate = account.usd_to_cad_rate ? parseFloat(account.usd_to_cad_rate) : 1;
+            const balanceCad = account.currency === 'USD' ? balance * rate : balance;
+            const balanceClass = balance < 0 ? 'negative' : (balance > 0 ? 'positive' : '');
+            const label = typeLabel(account.account_type);
+            const tagClass = typeTagClass(account.account_type);
+
+            // Show the native USD amount alongside the converted CAD figure
+            const usdNote = account.currency === 'USD'
+                ? `<span class="currency-note">${formatNative(balance, 'USD')} USD</span>`
+                : '';
+
+            const maskNote = account.account_mask ? ` · ····${account.account_mask}` : '';
+
+            const row = document.createElement('div');
+            row.className = 'account-row';
+            row.innerHTML = `
+                <div>
+                    <div class="account-name">${account.account_name}</div>
+                    <div class="account-type">${label}${maskNote}</div>
+                </div>
+                <div class="account-usd-note">${usdNote}</div>
+                <div class="account-balance ${balanceClass}">${formatCAD(balanceCad)}</div>
+                <div class="account-tag"><span class="tag ${tagClass}">${label}</span></div>
+            `;
+
+            accountsDiv.appendChild(row);
+        });
+
+        section.appendChild(header);
+        section.appendChild(accountsDiv);
+        panel.appendChild(section);
+    });
+}
+
+// ─── Trend chart ───────────────────────────────────────────────────────────
+
+let retirementChart = null;
+
+// Map range key → granularity for the API request
+function rangeToGranularity(range) {
+    if (range === '1y' || range === 'all') return 'monthly';
+    if (range === '90d' || range === '6m') return 'weekly';
+    return 'daily'; // 30d
+}
+
+// Return a cutoff Date for client-side filtering, or null for all time
+function rangeCutoffDate(range) {
+    const now = new Date();
+    switch (range) {
+        case '30d': { const d = new Date(now); d.setDate(d.getDate() - 30);       return d; }
+        case '90d': { const d = new Date(now); d.setDate(d.getDate() - 90);       return d; }
+        case '6m':  { const d = new Date(now); d.setMonth(d.getMonth() - 6);      return d; }
+        case '1y':  { const d = new Date(now); d.setFullYear(d.getFullYear() - 1); return d; }
+        default: return null; // 'all'
+    }
+}
+
+function calculateLinearRegression(xValues, yValues) {
+    const n = xValues.length;
+    if (n < 2) return null;
+    const sumX  = xValues.reduce((a, b) => a + b, 0);
+    const sumY  = yValues.reduce((a, b) => a + b, 0);
+    const sumXY = xValues.reduce((s, x, i) => s + x * yValues[i], 0);
+    const sumXX = xValues.reduce((s, x) => s + x * x, 0);
+    const slope     = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+    const intercept = (sumY - slope * sumX) / n;
+    return { slope, intercept };
+}
+
+async function renderTrendChart(range) {
+    const granularity = rangeToGranularity(range);
+    const cutoff      = rangeCutoffDate(range);
+    const cutoffStr   = cutoff ? cutoff.toLocaleDateString('en-CA') : null;
+
+    // Fetch aggregated data
+    const allData = await fetch(`/api/retirement_trend_data?granularity=${granularity}`)
+        .then(r => r.json());
+
+    const filteredData = cutoffStr
+        ? allData.filter(d => d.date >= cutoffStr)
+        : allData;
+
+    const labels = filteredData.map(d => formatDate(d.date));
+    const values = filteredData.map(d => parseFloat(d.total_retirement_cad));
+
+    // Trend line — fetch daily data for accuracy, then project onto display points
+    let trendLineData = null;
+    if (filteredData.length >= 2) {
+        const dailyAll = await fetch('/api/retirement_trend_data?granularity=daily')
+            .then(r => r.json());
+        const dailyFiltered = cutoffStr
+            ? dailyAll.filter(d => d.date >= cutoffStr)
+            : dailyAll;
+
+        if (dailyFiltered.length >= 2) {
+            const parseUTC  = s => { const [y,m,d] = s.split('-').map(Number); return Date.UTC(y, m-1, d); };
+            const firstMs   = parseUTC(dailyFiltered[0].date);
+            const msPerDay  = 86400000;
+            const xVals     = dailyFiltered.map(d => (parseUTC(d.date) - firstMs) / msPerDay);
+            const yVals     = dailyFiltered.map(d => parseFloat(d.total_retirement_cad));
+            const regression = calculateLinearRegression(xVals, yVals);
+            if (regression) {
+                trendLineData = filteredData.map(d => {
+                    const days = (parseUTC(d.date) - firstMs) / msPerDay;
+                    return regression.slope * days + regression.intercept;
+                });
+            }
+        }
+    }
+
+    if (retirementChart) retirementChart.destroy();
+
+    const datasets = [{
+        label: 'Total Retirement (CAD)',
+        data: values,
+        borderColor: '#667eea',
+        backgroundColor: 'rgba(102, 126, 234, 0.1)',
+        borderWidth: 3,
+        fill: true,
+        tension: 0.4,
+        pointRadius: 5,
+        pointHoverRadius: 7,
+        pointBackgroundColor: '#667eea',
+        pointBorderColor: '#fff',
+        pointBorderWidth: 2,
+    }];
+
+    if (trendLineData) {
+        datasets.push({
+            label: 'Trend',
+            data: trendLineData,
+            borderColor: 'rgba(149, 165, 166, 0.8)',
+            borderWidth: 2,
+            borderDash: [5, 5],
+            fill: false,
+            pointRadius: 0,
+            pointHoverRadius: 0,
+            tension: 0,
+        });
+    }
+
+    retirementChart = new Chart(document.getElementById('retirementTrendChart'), {
+        type: 'line',
+        data: { labels, datasets },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    display: !!trendLineData,
+                    position: 'top',
+                    align: 'end',
+                    labels: { usePointStyle: true, boxWidth: 6 },
+                },
+                tooltip: {
+                    mode: 'index',
+                    intersect: false,
+                    backgroundColor: 'rgba(0,0,0,0.8)',
+                    padding: 12,
+                    borderColor: '#667eea',
+                    borderWidth: 1,
+                    callbacks: {
+                        label(context) {
+                            const prefix = context.dataset.label === 'Trend' ? 'Trend: ' : '';
+                            return prefix + formatCAD(context.parsed.y);
+                        },
+                    },
+                },
+            },
+            scales: {
+                y: {
+                    beginAtZero: false,
+                    ticks: { callback: v => '$' + v.toLocaleString() },
+                    grid:  { color: 'rgba(0,0,0,0.05)' },
+                },
+                x: {
+                    grid: { display: false },
+                },
+            },
+            interaction: { mode: 'nearest', axis: 'x', intersect: false },
+        },
+    });
+}
+
+function setupChartButtons() {
+    document.querySelectorAll('.date-range-btn').forEach(btn => {
+        btn.addEventListener('click', function () {
+            document.querySelectorAll('.date-range-btn').forEach(b => b.classList.remove('active'));
+            this.classList.add('active');
+            renderTrendChart(this.dataset.range);
+        });
+    });
+}
+
+// ─── UI interactions ───────────────────────────────────────────────────────
+
+function toggleInstitution(header) {
+    const accountsDiv = header.nextElementSibling;
+    const chevron = header.querySelector('.chevron');
+    accountsDiv.classList.toggle('collapsed');
+    chevron.classList.toggle('open');
+}

--- a/public/retirement.html
+++ b/public/retirement.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retirement Accounts</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html, body {
+            height: 100%;
+            overflow-x: hidden;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #f5f7fa;
+            padding: 20px;
+            overflow-y: auto;
+        }
+
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        h1 {
+            color: #2c3e50;
+            margin-bottom: 30px;
+            font-size: 2rem;
+        }
+
+        /* ── Page tabs (shared with index.html) ─────────────────────────── */
+        .page-tabs {
+            display: flex;
+            gap: 8px;
+            margin-bottom: 30px;
+        }
+
+        .tab-link {
+            padding: 10px 20px;
+            border-radius: 8px;
+            text-decoration: none;
+            font-size: 0.95rem;
+            font-weight: 600;
+            transition: all 0.2s;
+            color: #7f8c8d;
+            background: white;
+            border: 1px solid #e0e0e0;
+            box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+        }
+
+        .tab-link:hover {
+            background: #f0f0f0;
+            color: #2c3e50;
+        }
+
+        .tab-link.active {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border-color: transparent;
+        }
+
+        /* ── Summary cards ──────────────────────────────────────────────── */
+        .summary-panel {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+
+        .card {
+            background: white;
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+        }
+
+        .card.primary {
+            grid-column: span 4;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+
+        .card-label {
+            font-size: 0.9rem;
+            opacity: 0.8;
+            margin-bottom: 8px;
+        }
+
+        .card-value {
+            font-size: 2.5rem;
+            font-weight: bold;
+            margin-bottom: 8px;
+        }
+
+        /* Per-type cards use a smaller value font */
+        .card:not(.primary) .card-value,
+        .type-positive {
+            font-size: 1.8rem !important;
+            font-weight: bold;
+            color: #27ae60;
+            margin-bottom: 8px;
+        }
+
+        .card-sub {
+            font-size: 0.85rem;
+            opacity: 0.75;
+        }
+
+        .card:not(.primary) .card-sub {
+            color: #7f8c8d;
+            opacity: 1;
+        }
+
+        /* ── Balances panel ─────────────────────────────────────────────── */
+        .balances-panel {
+            background: white;
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+            margin-bottom: 30px;
+        }
+
+        .balances-panel h2 {
+            color: #2c3e50;
+            margin-bottom: 20px;
+            font-size: 1.5rem;
+        }
+
+        .balances-panel h2 span {
+            color: #7f8c8d;
+            font-size: 0.9rem;
+            font-weight: normal;
+        }
+
+        /* ── Institution sections ───────────────────────────────────────── */
+        .institution {
+            margin-bottom: 20px;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            overflow: hidden;
+        }
+
+        .institution-header {
+            background: #f8f9fa;
+            padding: 15px 20px;
+            cursor: pointer;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-weight: 600;
+            color: #2c3e50;
+            user-select: none;
+        }
+
+        .institution-header:hover {
+            background: #e9ecef;
+        }
+
+        .institution-accounts {
+            padding: 10px;
+        }
+
+        .institution-accounts.collapsed {
+            display: none;
+        }
+
+        .chevron {
+            transition: transform 0.3s;
+        }
+
+        .chevron.open {
+            transform: rotate(180deg);
+        }
+
+        /* ── Account rows ───────────────────────────────────────────────── */
+        .account-row {
+            display: grid;
+            grid-template-columns: 2fr 1fr 1fr 100px;
+            padding: 12px 20px;
+            align-items: center;
+            border-bottom: 1px solid #f0f0f0;
+        }
+
+        .account-row:last-child {
+            border-bottom: none;
+        }
+
+        .account-name {
+            color: #2c3e50;
+            font-weight: 500;
+        }
+
+        .account-type {
+            color: #7f8c8d;
+            font-size: 0.9rem;
+        }
+
+        /* Native USD amount shown alongside the CAD balance */
+        .account-usd-note {
+            text-align: right;
+        }
+
+        .currency-note {
+            font-size: 0.8rem;
+            color: #95a5a6;
+        }
+
+        .account-balance {
+            text-align: right;
+            font-weight: 600;
+            font-size: 1.1rem;
+        }
+
+        .account-balance.positive { color: #27ae60; }
+        .account-balance.negative { color: #e74c3c; }
+
+        /* ── Type tag badges ────────────────────────────────────────────── */
+        .account-tag {
+            text-align: right;
+        }
+
+        .tag {
+            display: inline-block;
+            font-size: 0.75rem;
+            font-weight: 600;
+            padding: 3px 8px;
+            border-radius: 4px;
+            background: #f0f0f0;
+            color: #7f8c8d;
+        }
+
+        .tag-401k    { background: #eafaf1; color: #1e8449; }
+        .tag-ira     { background: #eaf4fb; color: #2471a3; }
+        .tag-rrsp    { background: #fdf2f8; color: #9b59b6; }
+        .tag-tfsa    { background: #fef9e7; color: #d68910; }
+        .tag-lira    { background: #fdedec; color: #cb4335; }
+        .tag-pension { background: #f4f6f7; color: #566573; }
+        .tag-other   { background: #f0f0f0; color: #7f8c8d; }
+
+        /* ── Trend chart panel ──────────────────────────────────────────── */
+        .chart-panel {
+            background: white;
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+            margin-bottom: 30px;
+        }
+
+        .chart-panel h2 {
+            color: #2c3e50;
+            margin-bottom: 20px;
+            font-size: 1.5rem;
+        }
+
+        .date-range-selector {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        .date-range-btn {
+            padding: 8px 16px;
+            border: 1px solid #ddd;
+            background: white;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            transition: all 0.2s;
+        }
+
+        .date-range-btn:hover { background: #f8f9fa; }
+
+        .date-range-btn.active {
+            background: #667eea;
+            color: white;
+            border-color: #667eea;
+        }
+
+        .chart-container {
+            position: relative;
+            height: 400px;
+            width: 100%;
+        }
+
+        /* ── Responsive ─────────────────────────────────────────────────── */
+        @media (max-width: 1200px) {
+            .summary-panel {
+                grid-template-columns: repeat(2, 1fr);
+            }
+            .card.primary {
+                grid-column: span 2;
+            }
+        }
+
+        @media (max-width: 768px) {
+            .summary-panel {
+                grid-template-columns: 1fr;
+            }
+            .card.primary {
+                grid-column: span 1;
+            }
+            .account-row {
+                grid-template-columns: 1fr 1fr;
+                gap: 8px;
+            }
+            .account-usd-note {
+                display: none;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🏦 Retirement Accounts</h1>
+
+        <div class="page-tabs">
+            <a href="/index.html" class="tab-link">💵 Liquid Cash</a>
+            <a href="/retirement.html" class="tab-link active">🏦 Retirement</a>
+        </div>
+
+        <!-- Summary cards — populated dynamically by retirement.js -->
+        <div class="summary-panel" id="summaryPanel">
+            <div class="card primary">
+                <div class="card-label">Total Retirement (CAD)</div>
+                <div class="card-value">Loading…</div>
+            </div>
+        </div>
+
+        <!-- Account balances — institutions + rows populated by retirement.js -->
+        <div class="balances-panel">
+            <h2>Retirement Account Balances <span></span></h2>
+        </div>
+
+        <!-- Trend chart -->
+        <div class="chart-panel">
+            <h2>Retirement Trend (CAD)</h2>
+            <div class="date-range-selector">
+                <button class="date-range-btn" data-range="30d">30 Days</button>
+                <button class="date-range-btn active" data-range="90d">90 Days</button>
+                <button class="date-range-btn" data-range="6m">6 Months</button>
+                <button class="date-range-btn" data-range="1y">1 Year</button>
+                <button class="date-range-btn" data-range="all">All Time</button>
+            </div>
+            <div class="chart-container">
+                <canvas id="retirementTrendChart"></canvas>
+            </div>
+        </div>
+    </div>
+
+    <script src="/js/retirement.js"></script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -361,10 +361,12 @@ app.get('/api/accounts', async (req, res) => {
         a.institution_name,
         a.account_name,
         a.account_type,
+        a.account_category,
         a.currency,
         a.account_mask,
         a.is_liability,
         a.is_active,
+        (a.plaid_account_id IS NOT NULL) AS is_plaid_connected,
         pi.plaid_item_id,
         COALESCE(pi.login_required, false) AS login_required
       FROM accounts a
@@ -426,6 +428,7 @@ app.get('/api/latest_balances', async (req, res) => {
       FROM accounts a
       LEFT JOIN balance_snapshots b ON a.id = b.account_id
       WHERE a.is_active = true
+        AND a.account_category = 'liquid'
         AND b.balance IS NOT NULL
         AND b.date = (
           SELECT MAX(date)
@@ -484,6 +487,7 @@ app.get('/api/summary', async (req, res) => {
       FROM balance_snapshots b
       JOIN accounts a ON b.account_id = a.id
       WHERE a.is_active = true
+        AND a.account_category = 'liquid'
         AND b.date = (
           SELECT MAX(date)
           FROM balance_snapshots
@@ -491,11 +495,13 @@ app.get('/api/summary', async (req, res) => {
         )
     `);
 
-    // Get the previous snapshot date for comparison (second most recent across all accounts)
+    // Get the previous snapshot date for comparison (second most recent across liquid accounts)
     const previousDateResult = await pool.query(`
-      SELECT DISTINCT date
-      FROM balance_snapshots
-      ORDER BY date DESC
+      SELECT DISTINCT b.date
+      FROM balance_snapshots b
+      JOIN accounts a ON b.account_id = a.id
+      WHERE a.is_active = true AND a.account_category = 'liquid'
+      ORDER BY b.date DESC
       LIMIT 1 OFFSET 1
     `);
 
@@ -518,6 +524,7 @@ app.get('/api/summary', async (req, res) => {
         FROM balance_snapshots b
         JOIN accounts a ON b.account_id = a.id
         WHERE a.is_active = true
+          AND a.account_category = 'liquid'
           AND b.date = $1
       `, [previousDate]);
 
@@ -614,6 +621,7 @@ app.get('/api/trend_data', async (req, res) => {
         FROM all_calendar_days d
         CROSS JOIN accounts a
         WHERE a.is_active = true
+          AND a.account_category = 'liquid'
       ),
 
       -- Aggregate to daily totals (sum across all accounts)
@@ -852,6 +860,212 @@ app.get('/api/account_history/:accountId', async (req, res) => {
 });
 
 // ===========================================
+// RETIREMENT ENDPOINTS
+// ===========================================
+
+// Get latest balances for all active retirement accounts
+app.get('/api/retirement_balances', async (req, res) => {
+  try {
+    const result = await pool.query(`
+      SELECT
+        a.id,
+        a.institution_name,
+        a.account_name,
+        a.account_type,
+        a.currency,
+        a.account_mask,
+        b.balance,
+        b.date,
+        er.rate AS usd_to_cad_rate
+      FROM accounts a
+      LEFT JOIN balance_snapshots b
+        ON a.id = b.account_id
+        AND b.date = (SELECT MAX(date) FROM balance_snapshots WHERE account_id = a.id)
+      LEFT JOIN exchange_rates er
+        ON er.from_currency = 'USD' AND er.to_currency = 'CAD'
+      WHERE a.is_active = true
+        AND a.account_category = 'retirement'
+        AND b.balance IS NOT NULL
+      ORDER BY a.institution_name, a.account_name
+    `);
+
+    res.json({
+      accounts: result.rows,
+      date: result.rows.length > 0 ? result.rows[0].date : null
+    });
+  } catch (error) {
+    console.error('Error fetching retirement balances:', error);
+    res.status(500).json({ error: 'Failed to fetch retirement balances' });
+  }
+});
+
+// Get summary totals for retirement accounts, grouped by account type, in CAD
+app.get('/api/retirement_summary', async (req, res) => {
+  try {
+    const result = await pool.query(`
+      SELECT
+        a.account_type,
+        SUM(
+          CASE
+            WHEN a.currency = 'CAD' THEN b.balance
+            WHEN a.currency = 'USD' THEN b.balance * er.rate
+            ELSE b.balance
+          END
+        ) AS total_cad,
+        COUNT(a.id) AS account_count
+      FROM accounts a
+      JOIN balance_snapshots b
+        ON b.account_id = a.id
+        AND b.date = (SELECT MAX(date) FROM balance_snapshots WHERE account_id = a.id)
+      LEFT JOIN exchange_rates er
+        ON er.from_currency = 'USD' AND er.to_currency = 'CAD'
+      WHERE a.is_active = true
+        AND a.account_category = 'retirement'
+      GROUP BY a.account_type
+      HAVING SUM(
+        CASE
+          WHEN a.currency = 'CAD' THEN b.balance
+          WHEN a.currency = 'USD' THEN b.balance * er.rate
+          ELSE b.balance
+        END
+      ) <> 0
+      ORDER BY a.account_type
+    `);
+
+    // Fetch exchange rate and latest date for the response envelope
+    const metaResult = await pool.query(`
+      SELECT er.rate AS usd_to_cad_rate, MAX(b.date) AS latest_date
+      FROM exchange_rates er
+      CROSS JOIN balance_snapshots b
+      JOIN accounts a ON b.account_id = a.id
+      WHERE er.from_currency = 'USD' AND er.to_currency = 'CAD'
+        AND a.is_active = true
+        AND a.account_category = 'retirement'
+      GROUP BY er.rate
+    `);
+
+    const rate = metaResult.rows.length > 0 ? parseFloat(metaResult.rows[0].usd_to_cad_rate) : null;
+    const date = metaResult.rows.length > 0 ? metaResult.rows[0].latest_date : null;
+
+    const byType = result.rows.map(row => ({
+      accountType: row.account_type,
+      totalCad: parseFloat(row.total_cad),
+      accountCount: parseInt(row.account_count, 10)
+    }));
+
+    const totalRetirementCad = byType.reduce((sum, t) => sum + t.totalCad, 0);
+
+    res.json({
+      date,
+      usdToCadRate: rate,
+      totalRetirementCad,
+      byType
+    });
+  } catch (error) {
+    console.error('Error fetching retirement summary:', error);
+    res.status(500).json({ error: 'Failed to fetch retirement summary' });
+  }
+});
+
+// Get balance history for retirement trend chart
+app.get('/api/retirement_trend_data', async (req, res) => {
+  try {
+    const validGranularities = ['daily', 'weekly', 'monthly'];
+    const granularity = validGranularities.includes(req.query.granularity) ? req.query.granularity : 'daily';
+
+    // Generate a complete daily series with carry-forward for each retirement account,
+    // then sum to a single CAD total per day (USD converted via stored rate).
+    const dailyResult = await pool.query(`
+      WITH
+      date_range AS (
+        SELECT
+          MIN(b.date) AS first_date,
+          CURRENT_DATE AS last_date
+        FROM balance_snapshots b
+        JOIN accounts a ON b.account_id = a.id
+        WHERE a.is_active = true AND a.account_category = 'retirement'
+      ),
+      all_calendar_days AS (
+        SELECT date::date AS date
+        FROM date_range,
+             generate_series(first_date, last_date, '1 day'::interval) AS date
+      ),
+      daily_account_balances AS (
+        SELECT
+          d.date,
+          a.id AS account_id,
+          a.currency,
+          (
+            SELECT b.balance
+            FROM balance_snapshots b
+            WHERE b.account_id = a.id AND b.date <= d.date
+            ORDER BY b.date DESC
+            LIMIT 1
+          ) AS balance,
+          (
+            SELECT b.usd_to_cad_rate
+            FROM balance_snapshots b
+            WHERE b.account_id = a.id AND b.date <= d.date
+            ORDER BY b.date DESC
+            LIMIT 1
+          ) AS rate
+        FROM all_calendar_days d
+        CROSS JOIN accounts a
+        WHERE a.is_active = true AND a.account_category = 'retirement'
+      ),
+      daily_totals AS (
+        SELECT
+          date,
+          SUM(
+            CASE
+              WHEN balance IS NOT NULL AND currency = 'CAD' THEN balance
+              WHEN balance IS NOT NULL AND currency = 'USD' THEN balance * COALESCE(rate, 1)
+              ELSE 0
+            END
+          ) AS total_retirement_cad
+        FROM daily_account_balances
+        GROUP BY date
+      )
+      SELECT date, total_retirement_cad
+      FROM daily_totals
+      ORDER BY date
+    `);
+
+    let finalResult = dailyResult.rows;
+
+    if (granularity === 'weekly') {
+      const todayStr = new Date().toLocaleDateString('en-CA');
+      finalResult = dailyResult.rows.filter(row => {
+        const [y, m, d] = row.date.split('-').map(Number);
+        const dayOfWeek = new Date(Date.UTC(y, m - 1, d)).getUTCDay();
+        return dayOfWeek === 0 || row.date === todayStr;
+      });
+    } else if (granularity === 'monthly') {
+      const monthlyData = {};
+      const todayStr = new Date().toLocaleDateString('en-CA');
+      dailyResult.rows.forEach(row => {
+        const [y, m, d] = row.date.split('-').map(Number);
+        const date = new Date(Date.UTC(y, m - 1, d));
+        const nextDay = new Date(date);
+        nextDay.setUTCDate(date.getUTCDate() + 1);
+        if (nextDay.getUTCDate() === 1) {
+          monthlyData[`${y}-${String(m).padStart(2, '0')}`] = row;
+        }
+        if (row.date === todayStr) {
+          monthlyData['today'] = row;
+        }
+      });
+      finalResult = Object.values(monthlyData).sort((a, b) => a.date.localeCompare(b.date));
+    }
+
+    res.json(finalResult);
+  } catch (error) {
+    console.error('Error fetching retirement trend data:', error);
+    res.status(500).json({ error: 'Failed to fetch retirement trend data' });
+  }
+});
+
+// ===========================================
 // PLAID API ENDPOINTS
 // ===========================================
 
@@ -968,25 +1182,39 @@ app.post('/api/exchange_public_token', async (req, res) => {
       access_token: accessToken,
     });
 
+    // Plaid subtypes that should be classified as retirement accounts
+    const RETIREMENT_SUBTYPES = new Set([
+      '401k', '401a', '403b', '457b', '457',
+      'ira', 'roth', 'roth 401k',
+      'pension', 'retirement',
+      'rrsp', 'tfsa', 'lira', 'rrif', 'resp',
+    ]);
+
     for (const account of accountsResponse.data.accounts) {
       const accountType = account.type;
       const subtype = account.subtype;
+      const subtypeLower = subtype?.toLowerCase() || '';
 
       // Auto-detect liabilities based on account type
       const liabilityTypes = ['mortgage', 'loan', 'line of credit', 'credit line'];
-      const isLiability = liabilityTypes.includes(subtype?.toLowerCase()) ||
+      const isLiability = liabilityTypes.includes(subtypeLower) ||
                           liabilityTypes.includes(accountType?.toLowerCase());
+
+      // Auto-classify retirement accounts from Plaid subtype
+      const accountCategory = RETIREMENT_SUBTYPES.has(subtypeLower) ? 'retirement' : 'liquid';
 
       await pool.query(`
         INSERT INTO accounts (
           plaid_item_id, institution_name, account_name, account_type,
-          currency, account_mask, plaid_account_id, is_liability
+          currency, account_mask, plaid_account_id, is_liability, account_category
         )
         SELECT
-          pi.id, $1, $2, $3, $4, $5, $6, $7
+          pi.id, $1, $2, $3, $4, $5, $6, $7, $8
         FROM plaid_items pi
-        WHERE pi.plaid_item_id = $8
-        ON CONFLICT (plaid_account_id) DO NOTHING
+        WHERE pi.plaid_item_id = $9
+        ON CONFLICT (plaid_account_id) DO UPDATE SET
+          account_category = EXCLUDED.account_category,
+          is_liability = EXCLUDED.is_liability
       `, [
         institutionName,
         account.name,
@@ -995,6 +1223,7 @@ app.post('/api/exchange_public_token', async (req, res) => {
         account.mask,
         account.account_id,
         isLiability,
+        accountCategory,
         itemId
       ]);
     }


### PR DESCRIPTION
## Summary

- **New Retirement page** (`retirement.html` + `retirement.js`): summary cards by account type, collapsible institution/account sections with CAD conversion, and a trend chart with 30d/90d/6m/1y/all-time range buttons + linear regression trend line
- **Auto-classification**: Plaid imports now detect retirement account subtypes (`401k`, `ira`, `roth`, `rrsp`, `tfsa`, `lira`, `pension`, etc.) and set `account_category = 'retirement'` automatically at insert time; reconnecting a bank also corrects any previously mis-categorized accounts
- **DB migration** (`migrations/010_add_account_category.js`): idempotent migration adds `account_category` column with CHECK constraint and index; also auto-fixes any existing accounts with retirement subtypes that were imported before this change
- **Liquid cash isolation**: `/api/summary`, `/api/latest_balances`, and `/api/trend_data` all filter to `account_category = 'liquid'` so retirement balances no longer bleed into the main dashboard
- **Three new API endpoints**: `/api/retirement_summary`, `/api/retirement_balances`, `/api/retirement_trend_data`
- **connect.html improvements**: accounts listed under each institution with type-tag badges, currency badges (CAD/USD), and a purple "Retirement" badge where applicable
- **Tab navigation**: added to both `index.html` and `retirement.html`
- **Seed data**: updated with three fictional retirement institutions (Summit Investments, Northern Pension Trust, Sun Life Financial) with historical balance snapshots

## Deployment checklist (sandbox + prd)

- [x] Run `node migrations/010_add_account_category.js` against each DB _before_ deploying — the migration is idempotent and safe to re-run
- [x] Deploy updated server code
- [x] Verify retirement accounts appear on `/retirement.html` and are absent from liquid cash dashboard

## Test plan

- [x] Fresh `docker compose up` with seeded data → retirement cards and chart populate correctly
- [x] Connect Plaid sandbox (First Platypus Bank) → 401k account appears on Retirement page, not Liquid Cash
- [x] Reconnecting an already-imported bank → account categories are re-evaluated correctly
- [x] Liquid cash dashboard shows no retirement accounts
- [x] Trend chart range buttons all work (30d, 90d, 6m, 1y, all time)
- [x] USD retirement accounts show native USD amount + converted CAD total

🤖 Generated with [Claude Code](https://claude.com/claude-code)