### PR TITLE
Add manual retirement account form with balance updates

### DIFF
--- a/public/js/retirement.js
+++ b/public/js/retirement.js
@@ -151,7 +151,7 @@ function renderSummaryCards(data) {
     });
 
     // Update the balances panel header date
-    const balancesHeading = document.querySelector('.balances-panel h2 span');
+    const balancesHeading = document.querySelector('.balances-panel-header h2 span');
     if (balancesHeading) {
         balancesHeading.textContent = data.date ? 'as of ' + formatDate(data.date) : '';
     }
@@ -398,3 +398,225 @@ function toggleInstitution(header) {
     accountsDiv.classList.toggle('collapsed');
     chevron.classList.toggle('open');
 }
+
+// ─── Add Account modal ─────────────────────────────────────────────────────
+
+function showAddAccountModal() {
+    // Clear form
+    document.getElementById('addInstitution').value = '';
+    document.getElementById('addAccountName').value = '';
+    document.getElementById('addAccountType').value = 'roth';
+    document.getElementById('addCurrency').value = 'CAD';
+    document.getElementById('addInitialBalance').value = '';
+    setAddAccountError('');
+
+    const btn = document.getElementById('saveAddAccountBtn');
+    btn.disabled = false;
+    btn.textContent = 'Save Account';
+
+    document.getElementById('addAccountModal').classList.add('show');
+    document.getElementById('addInstitution').focus();
+}
+
+function closeAddAccountModal() {
+    document.getElementById('addAccountModal').classList.remove('show');
+}
+
+function setAddAccountError(msg) {
+    const el = document.getElementById('addAccountError');
+    el.textContent = msg;
+    el.style.display = msg ? 'block' : 'none';
+}
+
+async function saveNewAccount() {
+    const institution_name = document.getElementById('addInstitution').value.trim();
+    const account_name = document.getElementById('addAccountName').value.trim();
+    const account_type = document.getElementById('addAccountType').value;
+    const currency = document.getElementById('addCurrency').value;
+    const initialBalanceRaw = document.getElementById('addInitialBalance').value.trim();
+
+    if (!institution_name) { setAddAccountError('Institution name is required.'); return; }
+    if (!account_name)     { setAddAccountError('Account name is required.'); return; }
+
+    const initial_balance = initialBalanceRaw !== '' ? parseFloat(initialBalanceRaw) : undefined;
+    if (initialBalanceRaw !== '' && isNaN(initial_balance)) {
+        setAddAccountError('Initial balance must be a valid number.');
+        return;
+    }
+
+    const btn = document.getElementById('saveAddAccountBtn');
+    btn.disabled = true;
+    btn.textContent = 'Saving…';
+    setAddAccountError('');
+
+    try {
+        const res = await fetch('/api/accounts/manual', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ institution_name, account_name, account_type, currency, initial_balance }),
+        });
+        const data = await res.json();
+
+        if (!res.ok) {
+            throw new Error(data.error || 'Failed to save account');
+        }
+
+        closeAddAccountModal();
+        await loadRetirementDashboard();
+    } catch (err) {
+        setAddAccountError(err.message || 'Something went wrong. Please try again.');
+        btn.disabled = false;
+        btn.textContent = 'Save Account';
+    }
+}
+
+// ─── Update Balances modal ─────────────────────────────────────────────────
+
+async function showUpdateBalancesModal() {
+    const body = document.getElementById('updateBalancesBody');
+    body.innerHTML = '<p style="color:#7f8c8d;padding:8px 0;">Loading accounts…</p>';
+
+    const btn = document.getElementById('saveUpdateBalancesBtn');
+    btn.disabled = false;
+    btn.textContent = 'Save Balances';
+
+    document.getElementById('updateBalancesModal').classList.add('show');
+
+    try {
+        const res = await fetch('/api/manual_accounts?category=retirement');
+        if (!res.ok) throw new Error('Failed to load accounts');
+        const accounts = await res.json();
+
+        if (!accounts.length) {
+            body.innerHTML = '<p style="color:#7f8c8d;">No manual accounts yet. Use <strong>＋ Add Account</strong> to get started.</p>';
+            btn.disabled = true;
+            return;
+        }
+
+        body.innerHTML = '';
+        accounts.forEach(account => {
+            const currentBalance = account.last_balance !== null && account.last_balance !== undefined
+                ? parseFloat(account.last_balance)
+                : '';
+
+            const item = document.createElement('div');
+            item.className = 'update-account-item';
+
+            const nameEl = document.createElement('div');
+            nameEl.className = 'update-account-name';
+            nameEl.textContent = account.account_name;
+
+            const metaEl = document.createElement('div');
+            metaEl.className = 'update-account-meta';
+            metaEl.textContent = `${account.institution_name} · ${typeLabel(account.account_type)}`;
+
+            const inputGroup = document.createElement('div');
+            inputGroup.className = 'update-account-input-group';
+
+            const input = document.createElement('input');
+            input.type = 'number';
+            input.className = 'update-account-input';
+            input.dataset.accountId = account.id;
+            input.value = currentBalance;
+            input.placeholder = 'Enter balance';
+            input.step = '0.01';
+            input.min = '0';
+
+            const currencyLabel = document.createElement('span');
+            currencyLabel.className = 'update-account-currency';
+            currencyLabel.textContent = account.currency;
+
+            inputGroup.appendChild(input);
+            inputGroup.appendChild(currencyLabel);
+            item.appendChild(nameEl);
+            item.appendChild(metaEl);
+            item.appendChild(inputGroup);
+            body.appendChild(item);
+        });
+    } catch (err) {
+        body.innerHTML = `<p style="color:#e74c3c;">Failed to load accounts: ${err.message}</p>`;
+        btn.disabled = true;
+    }
+}
+
+function closeUpdateBalancesModal() {
+    document.getElementById('updateBalancesModal').classList.remove('show');
+}
+
+async function saveRetirementBalances() {
+    const inputs = document.querySelectorAll('#updateBalancesBody .update-account-input');
+    const manualBalances = {};
+    let hasError = false;
+
+    inputs.forEach(input => {
+        const val = input.value.trim();
+        if (val === '') return; // Skip blank inputs
+        const num = parseFloat(val);
+        if (isNaN(num)) {
+            input.style.borderColor = '#e74c3c';
+            hasError = true;
+        } else {
+            input.style.borderColor = '';
+            manualBalances[input.dataset.accountId] = num;
+        }
+    });
+
+    if (hasError) return;
+    if (!Object.keys(manualBalances).length) {
+        closeUpdateBalancesModal();
+        return;
+    }
+
+    const btn = document.getElementById('saveUpdateBalancesBtn');
+    btn.disabled = true;
+    btn.textContent = 'Saving…';
+
+    try {
+        const res = await fetch('/api/refresh_balances', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ manualBalances }),
+        });
+        if (!res.ok) {
+            const data = await res.json();
+            throw new Error(data.error || 'Failed to save balances');
+        }
+
+        closeUpdateBalancesModal();
+        await loadRetirementDashboard();
+    } catch (err) {
+        btn.disabled = false;
+        btn.textContent = 'Save Balances';
+        // Show error inline above footer
+        const body = document.getElementById('updateBalancesBody');
+        let errEl = document.getElementById('updateBalancesError');
+        if (!errEl) {
+            errEl = document.createElement('div');
+            errEl.id = 'updateBalancesError';
+            errEl.style.cssText = 'background:#fdf0f0;border-left:4px solid #e74c3c;padding:10px 14px;border-radius:4px;color:#c0392b;font-size:0.9rem;margin-bottom:16px;';
+            body.prepend(errEl);
+        }
+        errEl.textContent = err.message || 'Something went wrong. Please try again.';
+    }
+}
+
+// ─── Keyboard / overlay close for modals ───────────────────────────────────
+
+document.addEventListener('keydown', function (e) {
+    if (e.key !== 'Escape') return;
+    if (document.getElementById('addAccountModal').classList.contains('show')) {
+        closeAddAccountModal();
+    }
+    if (document.getElementById('updateBalancesModal').classList.contains('show')) {
+        closeUpdateBalancesModal();
+    }
+});
+
+document.getElementById('addAccountModal').addEventListener('click', function (e) {
+    if (e.target === this) closeAddAccountModal();
+});
+
+document.getElementById('updateBalancesModal').addEventListener('click', function (e) {
+    if (e.target === this) closeUpdateBalancesModal();
+});
+

--- a/public/js/retirement.js
+++ b/public/js/retirement.js
@@ -1,7 +1,9 @@
 // retirement.js — Retirement accounts dashboard
 
-// ─── Auth guard ────────────────────────────────────────────────────────────
+// ─── Auth guard + event wiring ────────────────────────────────────────────
 document.addEventListener('DOMContentLoaded', function () {
+    setupModalEventListeners();
+
     fetch('/api/check-auth')
         .then(r => r.json())
         .then(data => {
@@ -600,23 +602,34 @@ async function saveRetirementBalances() {
     }
 }
 
-// ─── Keyboard / overlay close for modals ───────────────────────────────────
+// ─── Modal event listeners (called on DOMContentLoaded) ────────────────────
 
-document.addEventListener('keydown', function (e) {
-    if (e.key !== 'Escape') return;
-    if (document.getElementById('addAccountModal').classList.contains('show')) {
-        closeAddAccountModal();
-    }
-    if (document.getElementById('updateBalancesModal').classList.contains('show')) {
-        closeUpdateBalancesModal();
-    }
-});
+function setupModalEventListeners() {
+    // Panel action buttons
+    document.getElementById('addAccountBtn').addEventListener('click', showAddAccountModal);
+    document.getElementById('updateBalancesBtn').addEventListener('click', showUpdateBalancesModal);
 
-document.getElementById('addAccountModal').addEventListener('click', function (e) {
-    if (e.target === this) closeAddAccountModal();
-});
+    // Add Account modal
+    document.getElementById('closeAddAccountBtn').addEventListener('click', closeAddAccountModal);
+    document.getElementById('cancelAddAccountBtn').addEventListener('click', closeAddAccountModal);
+    document.getElementById('saveAddAccountBtn').addEventListener('click', saveNewAccount);
+    document.getElementById('addAccountModal').addEventListener('click', function (e) {
+        if (e.target === this) closeAddAccountModal();
+    });
 
-document.getElementById('updateBalancesModal').addEventListener('click', function (e) {
-    if (e.target === this) closeUpdateBalancesModal();
-});
+    // Update Balances modal
+    document.getElementById('closeUpdateBalancesBtn').addEventListener('click', closeUpdateBalancesModal);
+    document.getElementById('cancelUpdateBalancesBtn').addEventListener('click', closeUpdateBalancesModal);
+    document.getElementById('saveUpdateBalancesBtn').addEventListener('click', saveRetirementBalances);
+    document.getElementById('updateBalancesModal').addEventListener('click', function (e) {
+        if (e.target === this) closeUpdateBalancesModal();
+    });
+
+    // Escape key closes whichever modal is open
+    document.addEventListener('keydown', function (e) {
+        if (e.key !== 'Escape') return;
+        if (document.getElementById('addAccountModal').classList.contains('show')) closeAddAccountModal();
+        if (document.getElementById('updateBalancesModal').classList.contains('show')) closeUpdateBalancesModal();
+    });
+}
 

--- a/public/retirement.html
+++ b/public/retirement.html
@@ -625,8 +625,8 @@
             <div class="balances-panel-header">
                 <h2>Retirement Account Balances <span></span></h2>
                 <div class="balances-panel-actions">
-                    <button class="panel-action-btn secondary" onclick="showUpdateBalancesModal()">✏️ Update Balances</button>
-                    <button class="panel-action-btn primary" onclick="showAddAccountModal()">＋ Add Account</button>
+                    <button class="panel-action-btn secondary" id="updateBalancesBtn">✏️ Update Balances</button>
+                    <button class="panel-action-btn primary" id="addAccountBtn">＋ Add Account</button>
                 </div>
             </div>
         </div>
@@ -635,7 +635,7 @@
         <div class="ret-modal" id="addAccountModal">
             <div class="ret-modal-content">
                 <div class="ret-modal-header">
-                    <button class="ret-modal-close" onclick="closeAddAccountModal()">×</button>
+                    <button class="ret-modal-close" id="closeAddAccountBtn">×</button>
                     <h2>＋ Add Retirement Account</h2>
                     <p>Manually add an account not supported by Plaid</p>
                 </div>
@@ -682,8 +682,8 @@
                     </div>
                 </div>
                 <div class="ret-modal-footer">
-                    <button class="ret-modal-btn cancel" onclick="closeAddAccountModal()">Cancel</button>
-                    <button class="ret-modal-btn save" id="saveAddAccountBtn" onclick="saveNewAccount()">Save Account</button>
+                    <button class="ret-modal-btn cancel" id="cancelAddAccountBtn">Cancel</button>
+                    <button class="ret-modal-btn save" id="saveAddAccountBtn">Save Account</button>
                 </div>
             </div>
         </div>
@@ -692,7 +692,7 @@
         <div class="ret-modal" id="updateBalancesModal">
             <div class="ret-modal-content">
                 <div class="ret-modal-header">
-                    <button class="ret-modal-close" onclick="closeUpdateBalancesModal()">×</button>
+                    <button class="ret-modal-close" id="closeUpdateBalancesBtn">×</button>
                     <h2>✏️ Update Retirement Balances</h2>
                     <p>Enter current balances for your manual accounts</p>
                 </div>
@@ -700,8 +700,8 @@
                     <!-- Populated dynamically -->
                 </div>
                 <div class="ret-modal-footer">
-                    <button class="ret-modal-btn cancel" onclick="closeUpdateBalancesModal()">Cancel</button>
-                    <button class="ret-modal-btn save" id="saveUpdateBalancesBtn" onclick="saveRetirementBalances()">Save Balances</button>
+                    <button class="ret-modal-btn cancel" id="cancelUpdateBalancesBtn">Cancel</button>
+                    <button class="ret-modal-btn save" id="saveUpdateBalancesBtn">Save Balances</button>
                 </div>
             </div>
         </div>

--- a/public/retirement.html
+++ b/public/retirement.html
@@ -290,6 +290,292 @@
             width: 100%;
         }
 
+        /* ── Balances panel header ──────────────────────────────────────── */
+        .balances-panel-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+
+        .balances-panel-header h2 {
+            margin: 0;
+            color: #2c3e50;
+            font-size: 1.5rem;
+        }
+
+        .balances-panel-header h2 span {
+            color: #7f8c8d;
+            font-size: 0.9rem;
+            font-weight: normal;
+        }
+
+        .balances-panel-actions {
+            display: flex;
+            gap: 10px;
+            flex-shrink: 0;
+        }
+
+        .panel-action-btn {
+            padding: 8px 16px;
+            border: none;
+            border-radius: 8px;
+            font-size: 0.9rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .panel-action-btn.primary {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+
+        .panel-action-btn.primary:hover {
+            opacity: 0.9;
+        }
+
+        .panel-action-btn.secondary {
+            background: #f8f9fa;
+            color: #2c3e50;
+            border: 1px solid #e0e0e0;
+        }
+
+        .panel-action-btn.secondary:hover {
+            background: #e9ecef;
+        }
+
+        /* ── Shared modal base ───────────────────────────────────────────── */
+        .ret-modal {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.5);
+            z-index: 2000;
+            display: none;
+            justify-content: center;
+            align-items: center;
+            padding: 20px;
+        }
+
+        .ret-modal.show {
+            display: flex;
+        }
+
+        .ret-modal-content {
+            background: white;
+            border-radius: 16px;
+            max-width: 560px;
+            width: 100%;
+            max-height: 85vh;
+            display: flex;
+            flex-direction: column;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+        }
+
+        .ret-modal-header {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 24px;
+            border-radius: 16px 16px 0 0;
+            position: relative;
+        }
+
+        .ret-modal-header h2 {
+            margin: 0;
+            font-size: 1.4rem;
+        }
+
+        .ret-modal-header p {
+            margin: 6px 0 0 0;
+            opacity: 0.9;
+            font-size: 0.9rem;
+        }
+
+        .ret-modal-close {
+            position: absolute;
+            top: 20px;
+            right: 20px;
+            background: rgba(255, 255, 255, 0.2);
+            border: none;
+            color: white;
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            font-size: 1.3rem;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            line-height: 1;
+        }
+
+        .ret-modal-close:hover {
+            background: rgba(255, 255, 255, 0.3);
+        }
+
+        .ret-modal-body {
+            padding: 24px;
+            overflow-y: auto;
+            flex: 1;
+        }
+
+        .ret-modal-footer {
+            padding: 20px 24px;
+            border-top: 1px solid #e0e0e0;
+            display: flex;
+            gap: 12px;
+            justify-content: flex-end;
+        }
+
+        .ret-modal-btn {
+            padding: 10px 24px;
+            border: none;
+            border-radius: 6px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .ret-modal-btn.cancel {
+            background: #f8f9fa;
+            color: #2c3e50;
+        }
+
+        .ret-modal-btn.cancel:hover {
+            background: #e9ecef;
+        }
+
+        .ret-modal-btn.save {
+            background: #667eea;
+            color: white;
+        }
+
+        .ret-modal-btn.save:hover {
+            background: #5568d3;
+        }
+
+        .ret-modal-btn:disabled {
+            background: #95a5a6;
+            cursor: not-allowed;
+            opacity: 0.7;
+        }
+
+        /* ── Add account form fields ─────────────────────────────────────── */
+        .form-field {
+            margin-bottom: 20px;
+        }
+
+        .form-field label {
+            display: block;
+            font-weight: 600;
+            color: #2c3e50;
+            margin-bottom: 6px;
+            font-size: 0.9rem;
+        }
+
+        .form-field input,
+        .form-field select {
+            width: 100%;
+            padding: 10px 12px;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            font-size: 1rem;
+            font-family: inherit;
+            color: #2c3e50;
+            transition: border-color 0.2s;
+        }
+
+        .form-field input:focus,
+        .form-field select:focus {
+            outline: none;
+            border-color: #667eea;
+        }
+
+        .form-field input[type="number"] {
+            font-family: monospace;
+        }
+
+        .form-field .field-hint {
+            margin-top: 4px;
+            font-size: 0.8rem;
+            color: #95a5a6;
+        }
+
+        .form-row {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+        }
+
+        .ret-modal-error {
+            background: #fdf0f0;
+            border-left: 4px solid #e74c3c;
+            padding: 10px 14px;
+            border-radius: 4px;
+            color: #c0392b;
+            font-size: 0.9rem;
+            margin-bottom: 16px;
+            display: none;
+        }
+
+        /* ── Update balances rows ────────────────────────────────────────── */
+        .update-account-item {
+            margin-bottom: 20px;
+            padding-bottom: 20px;
+            border-bottom: 1px solid #e0e0e0;
+        }
+
+        .update-account-item:last-child {
+            border-bottom: none;
+            margin-bottom: 0;
+            padding-bottom: 0;
+        }
+
+        .update-account-name {
+            font-weight: 600;
+            color: #2c3e50;
+            margin-bottom: 2px;
+        }
+
+        .update-account-meta {
+            color: #7f8c8d;
+            font-size: 0.85rem;
+            margin-bottom: 8px;
+        }
+
+        .update-account-input-group {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+        }
+
+        .update-account-input {
+            flex: 1;
+            padding: 10px 12px;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            font-size: 1rem;
+            font-family: monospace;
+        }
+
+        .update-account-input:focus {
+            outline: none;
+            border-color: #667eea;
+        }
+
+        .update-account-currency {
+            color: #7f8c8d;
+            font-size: 0.9rem;
+            font-weight: 600;
+            min-width: 40px;
+        }
+
         /* ── Responsive ─────────────────────────────────────────────────── */
         @media (max-width: 1200px) {
             .summary-panel {
@@ -336,7 +622,88 @@
 
         <!-- Account balances — institutions + rows populated by retirement.js -->
         <div class="balances-panel">
-            <h2>Retirement Account Balances <span></span></h2>
+            <div class="balances-panel-header">
+                <h2>Retirement Account Balances <span></span></h2>
+                <div class="balances-panel-actions">
+                    <button class="panel-action-btn secondary" onclick="showUpdateBalancesModal()">✏️ Update Balances</button>
+                    <button class="panel-action-btn primary" onclick="showAddAccountModal()">＋ Add Account</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Add Account modal -->
+        <div class="ret-modal" id="addAccountModal">
+            <div class="ret-modal-content">
+                <div class="ret-modal-header">
+                    <button class="ret-modal-close" onclick="closeAddAccountModal()">×</button>
+                    <h2>＋ Add Retirement Account</h2>
+                    <p>Manually add an account not supported by Plaid</p>
+                </div>
+                <div class="ret-modal-body">
+                    <div class="ret-modal-error" id="addAccountError"></div>
+                    <div class="form-field">
+                        <label for="addInstitution">Institution</label>
+                        <input type="text" id="addInstitution" placeholder="e.g. Fidelity" autocomplete="organization">
+                    </div>
+                    <div class="form-field">
+                        <label for="addAccountName">Account Name</label>
+                        <input type="text" id="addAccountName" placeholder="e.g. Roth IRA" autocomplete="off">
+                    </div>
+                    <div class="form-row">
+                        <div class="form-field">
+                            <label for="addAccountType">Account Type</label>
+                            <select id="addAccountType">
+                                <option value="401k">401(k)</option>
+                                <option value="403b">403(b)</option>
+                                <option value="457b">457(b)</option>
+                                <option value="ira">IRA</option>
+                                <option value="roth" selected>Roth IRA</option>
+                                <option value="roth 401k">Roth 401(k)</option>
+                                <option value="rrsp">RRSP</option>
+                                <option value="tfsa">TFSA</option>
+                                <option value="lira">LIRA</option>
+                                <option value="rrif">RRIF</option>
+                                <option value="resp">RESP</option>
+                                <option value="pension">Pension</option>
+                            </select>
+                        </div>
+                        <div class="form-field">
+                            <label for="addCurrency">Currency</label>
+                            <select id="addCurrency">
+                                <option value="CAD">CAD</option>
+                                <option value="USD">USD</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="form-field">
+                        <label for="addInitialBalance">Initial Balance</label>
+                        <input type="number" id="addInitialBalance" placeholder="Optional" step="0.01" min="0">
+                        <div class="field-hint">Leave blank to add the account with no balance history yet</div>
+                    </div>
+                </div>
+                <div class="ret-modal-footer">
+                    <button class="ret-modal-btn cancel" onclick="closeAddAccountModal()">Cancel</button>
+                    <button class="ret-modal-btn save" id="saveAddAccountBtn" onclick="saveNewAccount()">Save Account</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Update Balances modal -->
+        <div class="ret-modal" id="updateBalancesModal">
+            <div class="ret-modal-content">
+                <div class="ret-modal-header">
+                    <button class="ret-modal-close" onclick="closeUpdateBalancesModal()">×</button>
+                    <h2>✏️ Update Retirement Balances</h2>
+                    <p>Enter current balances for your manual accounts</p>
+                </div>
+                <div class="ret-modal-body" id="updateBalancesBody">
+                    <!-- Populated dynamically -->
+                </div>
+                <div class="ret-modal-footer">
+                    <button class="ret-modal-btn cancel" onclick="closeUpdateBalancesModal()">Cancel</button>
+                    <button class="ret-modal-btn save" id="saveUpdateBalancesBtn" onclick="saveRetirementBalances()">Save Balances</button>
+                </div>
+            </div>
         </div>
 
         <!-- Trend chart -->

--- a/server.js
+++ b/server.js
@@ -381,12 +381,22 @@ app.get('/api/accounts', async (req, res) => {
   }
 });
 
-// Get manual accounts (accounts without plaid_account_id) with their last balances
+// Get manual accounts (accounts without plaid_account_id) with their last balances.
+// Accepts optional ?category=retirement (or 'liquid') to filter by account_category.
 app.get('/api/manual_accounts', async (req, res) => {
   try {
+    const { category } = req.query;
+    const params = [];
+    let categoryFilter = '';
+    if (category) {
+      params.push(category);
+      categoryFilter = `AND a.account_category = $1`;
+    }
+
     const result = await pool.query(`
       SELECT
         a.id,
+        a.institution_name,
         a.account_name,
         a.currency,
         a.account_type,
@@ -401,13 +411,65 @@ app.get('/api/manual_accounts', async (req, res) => {
       FROM accounts a
       WHERE a.plaid_account_id IS NULL
         AND a.is_active = true
+        ${categoryFilter}
       ORDER BY a.institution_name, a.account_name
-    `);
+    `, params);
 
     res.json(result.rows);
   } catch (error) {
     console.error('Error fetching manual accounts:', error);
     res.status(500).json({ error: 'Failed to fetch manual accounts' });
+  }
+});
+
+// Create a new manual retirement account (no Plaid connection).
+// Optionally records an initial balance snapshot for today.
+app.post('/api/accounts/manual', async (req, res) => {
+  try {
+    const { institution_name, account_name, account_type, currency, initial_balance } = req.body;
+
+    if (!institution_name || !account_name || !account_type || !currency) {
+      return res.status(400).json({ error: 'institution_name, account_name, account_type, and currency are required' });
+    }
+
+    if (!['CAD', 'USD'].includes(currency)) {
+      return res.status(400).json({ error: 'currency must be CAD or USD' });
+    }
+
+    const accountResult = await pool.query(`
+      INSERT INTO accounts
+        (institution_name, account_name, account_type, account_category, currency, is_liability, is_active)
+      VALUES ($1, $2, $3, 'retirement', $4, false, true)
+      RETURNING id, account_name, institution_name, account_type
+    `, [
+      institution_name.trim(),
+      account_name.trim(),
+      account_type.trim().toLowerCase(),
+      currency,
+    ]);
+
+    const account = accountResult.rows[0];
+
+    // Record an initial balance snapshot if one was provided
+    const parsedBalance = parseFloat(initial_balance);
+    if (initial_balance !== undefined && initial_balance !== null && initial_balance !== '' && !isNaN(parsedBalance) && parsedBalance >= 0) {
+      const rateResult = await pool.query(`
+        SELECT rate FROM exchange_rates WHERE from_currency = 'USD' AND to_currency = 'CAD'
+      `);
+      const rate = rateResult.rows.length > 0 ? parseFloat(rateResult.rows[0].rate) : null;
+      const today = new Date().toISOString().split('T')[0];
+
+      await pool.query(`
+        INSERT INTO balance_snapshots (account_id, balance, date, usd_to_cad_rate)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (account_id, date) DO UPDATE SET balance = $2, usd_to_cad_rate = $4
+      `, [account.id, parsedBalance, today, rate]);
+    }
+
+    res.json({ success: true, account });
+  } catch (error) {
+    console.error('Error creating manual account:', error);
+    res.status(500).json({ error: 'Failed to create manual account' });
   }
 });
 


### PR DESCRIPTION
## Summary

- Adds **＋ Add Account** button and modal to the Retirement page — lets you create a manual retirement account (institution, name, type, currency, optional initial balance) entirely in the browser, no CLI needed
- Adds **✏️ Update Balances** button and modal — shows all existing manual retirement accounts pre-populated with their last known balance so you can record an updated value
- New `POST /api/accounts/manual` endpoint creates the account row and optionally inserts the first balance snapshot in one request
- Updated `GET /api/manual_accounts` to accept an optional `?category=retirement` filter and now returns `institution_name` for display

## Test plan

- [x] `npm start`, navigate to Retirement tab
- [x] Click **＋ Add Account** → fill in Fidelity / Roth IRA / Roth IRA type / USD / 42000 → Save → account appears in balances list with correct tag
- [x] Click **✏️ Update Balances** → account appears pre-populated with 42000 → change to 43000 → Save → balance updates on page
- [x] Verify escape key and clicking the overlay both close each modal
- [x] Verify error message appears if required fields are left blank on Add Account
- [x] Confirm DB: `SELECT * FROM accounts WHERE plaid_account_id IS NULL AND account_category = 'retirement';`
- [x] Confirm trend chart still loads correctly after adding the account

🤖 Generated with [Claude Code](https://claude.com/claude-code)