### PR TITLE
Add scoped refresh buttons with shared modal module

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,31 +39,62 @@
             align-items: center;
         }
 
-        .header-actions {
+        /* ── Tab row with global button ─── */
+        .page-tabs-row {
             display: flex;
-            gap: 10px;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            margin-bottom: 30px;
         }
 
-       .refresh-btn {
-           background: #667eea;
-           color: white;
-           border: none;
-           padding: 10px 20px;
-           border-radius: 8px;
-           cursor: pointer;
-           font-size: 0.9rem;
-           font-weight: 600;
-           transition: background 0.2s;
-       }
+        .page-tabs-row .tabs-left {
+            display: flex;
+            gap: 8px;
+        }
 
-       .refresh-btn:hover {
-           background: #5568d3;
-       }
+        /* ── Shared button styles ──────── */
+        .btn-refresh-all {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            padding: 10px 18px;
+            border-radius: 8px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            font-weight: 600;
+            transition: opacity 0.2s;
+            white-space: nowrap;
+        }
+        .btn-refresh-all:hover    { opacity: 0.9; }
+        .btn-refresh-all:disabled { opacity: 0.6; cursor: not-allowed; }
 
-       .refresh-btn:disabled {
-           background: #95a5a6;
-           cursor: not-allowed;
-       }
+        .btn-panel-action {
+            padding: 8px 14px;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            cursor: pointer;
+            background: white;
+            color: #2c3e50;
+            transition: background 0.2s;
+            white-space: nowrap;
+        }
+        .btn-panel-action:hover    { background: #f0f0f0; }
+        .btn-panel-action:disabled { opacity: 0.6; cursor: not-allowed; }
+
+        /* ── Balances panel header ─────── */
+        .balances-panel-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+        .balances-panel-header h2 { margin: 0; }
+        .balances-panel-actions   { display: flex; gap: 8px; }
 
         .summary-panel {
             display: grid;
@@ -656,16 +687,14 @@
 </head>
 <body>
     <div class="container">
-        <h1>
-            💰 Financial Dashboard
-            <div class="header-actions">
-                <button class="refresh-btn" id="refreshBtn">🔄 Refresh Balances</button>
-            </div>
-        </h1>
+        <h1>💰 Financial Dashboard</h1>
 
-        <div class="page-tabs">
-            <a href="/index.html" class="tab-link active">💵 Liquid Cash</a>
-            <a href="/retirement.html" class="tab-link">🏦 Retirement</a>
+        <div class="page-tabs-row">
+            <div class="tabs-left">
+                <a href="/index.html" class="tab-link active">💵 Liquid Cash</a>
+                <a href="/retirement.html" class="tab-link">🏦 Retirement</a>
+            </div>
+            <button class="btn-refresh-all" id="refreshAllBtn">🔄 Refresh All Balances</button>
         </div>
 
         <div class="summary-panel">
@@ -701,7 +730,12 @@
         </div>
 
         <div class="balances-panel">
-            <h2>Current Account Balances <span style="color: #7f8c8d; font-size: 0.9rem; font-weight: normal;">Loading...</span></h2>
+            <div class="balances-panel-header">
+                <h2>Current Account Balances <span id="balancesDateNote" style="color:#7f8c8d;font-size:0.9rem;font-weight:normal;">Loading...</span></h2>
+                <div class="balances-panel-actions">
+                    <button class="btn-panel-action" id="refreshCashBtn">🔄 Refresh Cash Balances</button>
+                </div>
+            </div>
         </div>
 
         <div class="chart-panel">
@@ -744,26 +778,7 @@
         </div>
     </div>
 
-    <!-- Manual Balance Entry Modal -->
-    <div class="manual-balance-modal" id="manualBalanceModal">
-        <div class="manual-balance-content">
-            <div class="manual-balance-header">
-                <button class="manual-balance-close" id="closeManualModalBtn">×</button>
-                <h2>💰 Update Manual Account Balances</h2>
-                <p id="manualModalSubtitle">Enter balances for accounts not managed by Plaid</p>
-            </div>
-
-            <div class="manual-balance-body" id="manualBalanceBody">
-                <!-- Account inputs will be populated here -->
-            </div>
-
-            <div class="manual-balance-footer">
-                <button class="manual-balance-btn cancel" id="cancelManualBtn">Cancel</button>
-                <button class="manual-balance-btn save" id="saveManualBtn">Save Balances</button>
-            </div>
-        </div>
-    </div>
-
+    <script src="/js/refresh-modal.js"></script>
     <script src="/js/dashboard.js"></script>
 </body>
 </html>

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -16,8 +16,13 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function setupEventListeners() {
-    // Refresh button
-    document.getElementById('refreshBtn').addEventListener('click', refreshBalances);
+    // Refresh buttons — all delegate to the shared triggerRefresh() from refresh-modal.js
+    document.getElementById('refreshAllBtn').addEventListener('click', function () {
+        triggerRefresh(null, this, loadDashboard);
+    });
+    document.getElementById('refreshCashBtn').addEventListener('click', function () {
+        triggerRefresh('liquid', this, loadDashboard);
+    });
 
     // Date range buttons
     document.querySelectorAll('.date-range-btn').forEach(btn => {
@@ -41,19 +46,9 @@ function setupEventListeners() {
     // Close side panel button
     document.getElementById('closeSidePanelBtn').addEventListener('click', closeSidePanel);
 
-    // Manual balance modal close button
-    document.getElementById('closeManualModalBtn').addEventListener('click', closeManualBalanceModal);
-
-    // Manual balance modal buttons
-    document.getElementById('cancelManualBtn').addEventListener('click', cancelManualBalances);
-    document.getElementById('saveManualBtn').addEventListener('click', saveManualBalances);
-
-    // Escape key to close panels
+    // Escape key to close side panel (refresh modal handles its own Escape key)
     document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') {
-            closeSidePanel();
-            closeManualBalanceModal();
-        }
+        if (e.key === 'Escape') closeSidePanel();
     });
 }
 
@@ -106,7 +101,8 @@ function updateSummaryCards(data) {
     cards[3].querySelector('.card-change').textContent = (usdCcChange >= 0 ? '▲' : '▼') + ' ' + formatCurrency(Math.abs(usdCcChange));
     cards[3].querySelector('.card-change').className = 'card-change ' + (usdCcChange >= 0 ? 'positive' : 'negative');
 
-    document.querySelector('.balances-panel h2 span').textContent = 'as of ' + formatDate(data.date);
+    const dateNote = document.getElementById('balancesDateNote');
+    if (dateNote) dateNote.textContent = 'as of ' + formatDate(data.date);
 }
 
 function updateAccountBalances(data) {
@@ -586,221 +582,4 @@ function closeSidePanel() {
     document.querySelector('.container').style.filter = '';
 }
 
-function closeManualBalanceModal() {
-    document.getElementById('manualBalanceModal').classList.remove('show');
-}
 
-let plaidRefreshResult = null;
-let plaidRefreshPromise = null;
-
-async function refreshBalances() {
-    const btn = document.getElementById('refreshBtn');
-
-    btn.disabled = true;
-    btn.textContent = '⏳ Refreshing...';
-
-    try {
-        // Step 1: Check for manual accounts FIRST (fast query)
-        const manualAccountsResponse = await fetch('/api/manual_accounts');
-        const manualAccounts = await manualAccountsResponse.json();
-
-        // Step 2: Start Plaid refresh in background (don't await yet)
-        plaidRefreshPromise = fetch('/api/refresh_balances', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' }
-        }).then(r => r.json());
-
-        // Step 3: Show manual modal immediately if needed
-        if (manualAccounts.length > 0) {
-            // Get exchange rate for modal display
-            const rateResponse = await fetch('/api/exchange_rate');
-            const rateData = await rateResponse.json();
-            const today = new Date().toLocaleDateString('en-CA');
-
-            // Show modal NOW (Plaid still running in background)
-            showManualBalanceModal(manualAccounts, today, rateData.rate);
-
-            // Store the result when Plaid finishes
-            plaidRefreshPromise.then(result => {
-                plaidRefreshResult = result;
-            }).catch(error => {
-                console.error('Background Plaid refresh failed:', error);
-            });
-        } else {
-            // No manual accounts, wait for Plaid and show success
-            const result = await plaidRefreshPromise;
-            if (result.success) {
-                showFinalSuccess(result);
-            } else {
-                alert('❌ Failed to refresh Plaid accounts.');
-            }
-            btn.disabled = false;
-            btn.textContent = '🔄 Refresh Balances';
-        }
-
-    } catch (error) {
-        alert('❌ Error: ' + error.message);
-        btn.disabled = false;
-        btn.textContent = '🔄 Refresh Balances';
-    }
-}
-
-function showManualBalanceModal(accounts, date, exchangeRate) {
-    const modal = document.getElementById('manualBalanceModal');
-    const body = document.getElementById('manualBalanceBody');
-    const subtitle = document.getElementById('manualModalSubtitle');
-
-    subtitle.textContent = `Date: ${date}  |  Exchange Rate: ${exchangeRate.toFixed(4)}`;
-
-    // Build the form
-    body.innerHTML = '';
-
-    let hasLiabilities = false;
-
-    accounts.forEach(account => {
-        if (account.is_liability) hasLiabilities = true;
-
-        const item = document.createElement('div');
-        item.className = 'manual-account-item';
-
-        const lastBalance = account.last_balance !== null ? Math.abs(parseFloat(account.last_balance)) : '';
-
-        item.innerHTML = `
-            <div class="manual-account-name">${account.account_name}</div>
-            <div class="manual-account-current">
-                ${account.account_type} • ${account.currency}
-                ${account.last_balance !== null ? ` • Current: ${formatCurrency(account.last_balance)}` : ''}
-            </div>
-            <div class="manual-account-input-group">
-                <input
-                    type="number"
-                    step="0.01"
-                    class="manual-account-input"
-                    id="manual-input-${account.id}"
-                    data-account-id="${account.id}"
-                    data-is-liability="${account.is_liability}"
-                    value="${lastBalance}"
-                    placeholder="Enter balance"
-                >
-                <span class="manual-account-currency">${account.currency}</span>
-            </div>
-        `;
-
-        body.appendChild(item);
-    });
-
-    // Add liability help note if needed
-    if (hasLiabilities) {
-        const helpNote = document.createElement('div');
-        helpNote.className = 'liability-help';
-        helpNote.innerHTML = 'ℹ️ <strong>Liability accounts:</strong> Enter positive numbers (e.g., 15606.10). They will be saved as negative automatically.';
-        body.appendChild(helpNote);
-    }
-
-    modal.classList.add('show');
-}
-
-function closeManualBalanceModal() {
-    document.getElementById('manualBalanceModal').classList.remove('show');
-}
-
-function cancelManualBalances() {
-    closeManualBalanceModal();
-
-    // Wait for Plaid to finish before showing success
-    if (plaidRefreshPromise) {
-        plaidRefreshPromise.then(result => {
-            if (result.success) {
-                showFinalSuccess(result);
-            }
-        }).catch(error => {
-            console.error('Plaid refresh error:', error);
-        });
-    }
-
-    // Re-enable refresh button
-    const btn = document.getElementById('refreshBtn');
-    btn.disabled = false;
-    btn.textContent = '🔄 Refresh Balances';
-}
-
-async function saveManualBalances() {
-    const saveBtn = document.querySelector('.manual-balance-btn.save');
-    const cancelBtn = document.querySelector('.manual-balance-btn.cancel');
-
-    // Disable buttons
-    saveBtn.disabled = true;
-    cancelBtn.disabled = true;
-
-    const inputs = document.querySelectorAll('.manual-account-input');
-    const manualBalances = {};
-
-    inputs.forEach(input => {
-        const accountId = input.dataset.accountId;
-        const value = input.value.trim();
-
-        if (value !== '') {
-            manualBalances[accountId] = value;
-        }
-    });
-
-    try {
-        // Wait for Plaid to finish first
-        saveBtn.textContent = 'Waiting for Plaid refresh...';
-        const plaidResult = await plaidRefreshPromise;
-
-        if (!plaidResult.success) {
-            alert('❌ Plaid refresh failed. Manual balances not saved.');
-            saveBtn.disabled = false;
-            cancelBtn.disabled = false;
-            saveBtn.textContent = 'Save Balances';
-            return;
-        }
-
-        // Now save manual balances
-        saveBtn.textContent = 'Saving manual balances...';
-        const response = await fetch('/api/refresh_balances', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ manualBalances })
-        });
-
-        const result = await response.json();
-
-        if (result.success) {
-            closeManualBalanceModal();
-
-            // Combine totals from both calls
-            const combinedResult = {
-                success: true,
-                accountsUpdated: plaidResult.accountsUpdated + result.manualAccountsUpdated,
-                date: result.date,
-                exchangeRate: result.exchangeRate
-            };
-
-            showFinalSuccess(combinedResult);
-            loadDashboard();
-        } else {
-            alert('❌ Failed to save manual balances.');
-            saveBtn.disabled = false;
-            cancelBtn.disabled = false;
-            saveBtn.textContent = 'Save Balances';
-        }
-
-    } catch (error) {
-        alert('❌ Error: ' + error.message);
-        saveBtn.disabled = false;
-        cancelBtn.disabled = false;
-        saveBtn.textContent = 'Save Balances';
-    } finally {
-        // Re-enable refresh button
-        const btn = document.getElementById('refreshBtn');
-        btn.disabled = false;
-        btn.textContent = '🔄 Refresh Balances';
-    }
-}
-
-function showFinalSuccess(result) {
-    alert(`✅ Successfully refreshed ${result.accountsUpdated} accounts!\n\nDate: ${result.date}\nExchange Rate: ${result.exchangeRate.toFixed(4)}`);
-    loadDashboard();
-}

--- a/public/js/refresh-modal.js
+++ b/public/js/refresh-modal.js
@@ -1,0 +1,423 @@
+// refresh-modal.js — Shared "refresh + manual balances" modal used by all pages.
+//
+// Usage:
+//   triggerRefresh(category, triggerBtn, reloadFn)
+//     category   – 'liquid' | 'retirement' | null (null = all)
+//     triggerBtn – the <button> element that was clicked (disabled during operation)
+//     reloadFn   – function to call after a successful save to refresh page data
+
+(function () {
+    // ─── Inject modal CSS once ──────────────────────────────────────────────
+
+    const STYLE_ID = 'refresh-modal-styles';
+    if (!document.getElementById(STYLE_ID)) {
+        const style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.textContent = `
+            .refresh-balance-modal {
+                position: fixed;
+                top: 0; left: 0; right: 0; bottom: 0;
+                background: rgba(0,0,0,0.5);
+                z-index: 2000;
+                display: none;
+                justify-content: center;
+                align-items: center;
+                padding: 20px;
+            }
+            .refresh-balance-modal.show { display: flex; }
+
+            .refresh-balance-content {
+                background: white;
+                border-radius: 16px;
+                max-width: 600px;
+                width: 100%;
+                max-height: 80vh;
+                display: flex;
+                flex-direction: column;
+                box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+            }
+
+            .refresh-balance-header {
+                background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                color: white;
+                padding: 24px;
+                border-radius: 16px 16px 0 0;
+                position: relative;
+            }
+            .refresh-balance-header h2 { margin: 0; font-size: 1.5rem; }
+            .refresh-balance-header p  { margin: 8px 0 0; opacity: 0.9; font-size: 0.9rem; }
+
+            .refresh-balance-close {
+                position: absolute;
+                top: 20px; right: 20px;
+                background: rgba(255,255,255,0.2);
+                border: none;
+                color: white;
+                width: 32px; height: 32px;
+                border-radius: 50%;
+                font-size: 1.3rem;
+                cursor: pointer;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                line-height: 1;
+            }
+            .refresh-balance-close:hover { background: rgba(255,255,255,0.3); }
+
+            .refresh-balance-body {
+                padding: 24px;
+                overflow-y: auto;
+                flex: 1;
+            }
+
+            .refresh-account-item {
+                margin-bottom: 24px;
+                padding-bottom: 24px;
+                border-bottom: 1px solid #e0e0e0;
+            }
+            .refresh-account-item:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
+
+            .refresh-account-name    { font-weight: 600; color: #2c3e50; margin-bottom: 4px; }
+            .refresh-account-current { color: #7f8c8d; font-size: 0.85rem; margin-bottom: 8px; }
+
+            .refresh-account-input-group { display: flex; gap: 8px; align-items: center; }
+
+            .refresh-account-input {
+                flex: 1;
+                padding: 10px 12px;
+                border: 1px solid #ddd;
+                border-radius: 6px;
+                font-size: 1rem;
+                font-family: monospace;
+            }
+            .refresh-account-input:focus { outline: none; border-color: #667eea; }
+
+            .refresh-account-currency { color: #7f8c8d; font-size: 0.9rem; font-weight: 600; min-width: 40px; }
+
+            .refresh-liability-help {
+                background: #fff3cd;
+                border-left: 4px solid #ffc107;
+                padding: 12px;
+                border-radius: 4px;
+                margin-top: 16px;
+                font-size: 0.85rem;
+                color: #856404;
+            }
+
+            .refresh-balance-footer {
+                padding: 20px 24px;
+                border-top: 1px solid #e0e0e0;
+                display: flex;
+                gap: 12px;
+                justify-content: flex-end;
+            }
+
+            .refresh-balance-btn {
+                padding: 10px 24px;
+                border: none;
+                border-radius: 6px;
+                font-size: 1rem;
+                font-weight: 600;
+                cursor: pointer;
+                transition: all 0.2s;
+            }
+            .refresh-balance-btn.cancel { background: #f8f9fa; color: #2c3e50; }
+            .refresh-balance-btn.cancel:hover { background: #e9ecef; }
+            .refresh-balance-btn.save { background: #667eea; color: white; }
+            .refresh-balance-btn.save:hover { background: #5568d3; }
+            .refresh-balance-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+        `;
+        document.head.appendChild(style);
+    }
+
+    // ─── Inject modal HTML once ─────────────────────────────────────────────
+
+    const MODAL_ID = 'refreshBalanceModal';
+    if (!document.getElementById(MODAL_ID)) {
+        const modal = document.createElement('div');
+        modal.className = 'refresh-balance-modal';
+        modal.id = MODAL_ID;
+        modal.innerHTML = `
+            <div class="refresh-balance-content">
+                <div class="refresh-balance-header">
+                    <button class="refresh-balance-close" id="closeRefreshModalBtn">×</button>
+                    <h2 id="refreshModalTitle">💰 Update Manual Account Balances</h2>
+                    <p id="refreshModalSubtitle"></p>
+                </div>
+                <div class="refresh-balance-body" id="refreshModalBody"></div>
+                <div class="refresh-balance-footer">
+                    <button class="refresh-balance-btn cancel" id="cancelRefreshModalBtn">Cancel</button>
+                    <button class="refresh-balance-btn save"   id="saveRefreshModalBtn">Save Balances</button>
+                </div>
+            </div>
+        `;
+        document.body.appendChild(modal);
+
+        // Wire up close/cancel buttons and Escape key
+        document.getElementById('closeRefreshModalBtn').addEventListener('click', _cancelModal);
+        document.getElementById('cancelRefreshModalBtn').addEventListener('click', _cancelModal);
+        document.getElementById('saveRefreshModalBtn').addEventListener('click', saveRefreshBalances);
+        modal.addEventListener('click', e => { if (e.target === modal) _cancelModal(); });
+        document.addEventListener('keydown', e => {
+            if (e.key === 'Escape' && modal.classList.contains('show')) _cancelModal();
+        });
+    }
+
+    // ─── Module state ───────────────────────────────────────────────────────
+
+    let _triggerBtn   = null;   // button that started the refresh
+    let _reloadFn     = null;   // page-specific data reload function
+    let _plaidPromise = null;   // background Plaid refresh promise
+    let _plaidResult  = null;   // resolved Plaid result (stored for save step)
+
+    // ─── Public API ─────────────────────────────────────────────────────────
+
+    /**
+     * Kick off a scoped refresh:
+     *   1. Fetch manual accounts for the given category (or all).
+     *   2. Fire the Plaid refresh in the background.
+     *   3. If there are manual accounts, show the modal immediately.
+     *      Otherwise wait for Plaid and show a success alert.
+     *
+     * @param {string|null} category  'liquid' | 'retirement' | null
+     * @param {HTMLElement} triggerBtn  The button that was clicked.
+     * @param {Function}    reloadFn    Called after a successful save.
+     */
+    window.triggerRefresh = async function (category, triggerBtn, reloadFn) {
+        _triggerBtn  = triggerBtn;
+        _reloadFn    = reloadFn;
+        _plaidResult = null;
+
+        const originalLabel = triggerBtn.textContent;
+        triggerBtn.disabled = true;
+        triggerBtn.textContent = '⏳ Refreshing...';
+
+        try {
+            // Step 1 — fetch manual accounts for this scope (fast)
+            const manualUrl = category
+                ? `/api/manual_accounts?category=${category}`
+                : '/api/manual_accounts';
+            const manualAccounts = await fetch(manualUrl).then(r => r.json());
+
+            // Step 2 — fire Plaid refresh in background
+            const body = category ? { category } : {};
+            _plaidPromise = fetch('/api/refresh_balances', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            }).then(r => r.json());
+
+            if (manualAccounts.length > 0) {
+                // Step 3a — show manual modal immediately (Plaid still running)
+                const rateData = await fetch('/api/exchange_rate').then(r => r.json());
+                const today = new Date().toLocaleDateString('en-CA');
+                _showModal(manualAccounts, today, rateData.rate, category);
+
+                // Store Plaid result when it lands
+                _plaidPromise
+                    .then(result  => { _plaidResult = result; })
+                    .catch(err    => { console.error('Background Plaid refresh failed:', err); });
+            } else {
+                // Step 3b — no manual accounts, just wait for Plaid
+                const result = await _plaidPromise;
+                _restoreButton(originalLabel);
+                if (result.success) {
+                    _showSuccess(result);
+                    reloadFn();
+                } else {
+                    alert('❌ Plaid refresh failed.');
+                }
+            }
+        } catch (err) {
+            alert('❌ Error: ' + err.message);
+            _restoreButton(originalLabel);
+        }
+    };
+
+    // ─── Modal internals ────────────────────────────────────────────────────
+
+    const TITLES = {
+        liquid:     '💰 Update Manual Cash Balances',
+        retirement: '💰 Update Manual Retirement Balances',
+        null:       '💰 Update Manual Account Balances',
+    };
+
+    function _showModal(accounts, date, exchangeRate, category) {
+        const modal    = document.getElementById(MODAL_ID);
+        const body     = document.getElementById('refreshModalBody');
+        const title    = document.getElementById('refreshModalTitle');
+        const subtitle = document.getElementById('refreshModalSubtitle');
+        const saveBtn  = document.getElementById('saveRefreshModalBtn');
+
+        title.textContent    = TITLES[category] ?? TITLES[null];
+        subtitle.textContent = `Date: ${date}  |  Exchange Rate: ${parseFloat(exchangeRate).toFixed(4)}`;
+
+        saveBtn.disabled    = false;
+        saveBtn.textContent = 'Save Balances';
+
+        body.innerHTML = '';
+        let hasLiabilities = false;
+
+        accounts.forEach(account => {
+            if (account.is_liability) hasLiabilities = true;
+
+            const lastBalance = account.last_balance !== null
+                ? Math.abs(parseFloat(account.last_balance))
+                : '';
+
+            const item = document.createElement('div');
+            item.className = 'refresh-account-item';
+
+            const nameEl = document.createElement('div');
+            nameEl.className = 'refresh-account-name';
+            nameEl.textContent = account.account_name;
+
+            const currentEl = document.createElement('div');
+            currentEl.className = 'refresh-account-current';
+            currentEl.textContent = [
+                account.account_type,
+                account.currency,
+                account.last_balance !== null
+                    ? `Current: ${_formatCurrency(account.last_balance, account.currency)}`
+                    : null,
+            ].filter(Boolean).join(' • ');
+
+            const inputGroup = document.createElement('div');
+            inputGroup.className = 'refresh-account-input-group';
+
+            const input = document.createElement('input');
+            input.type = 'number';
+            input.step = '0.01';
+            input.className = 'refresh-account-input';
+            input.dataset.accountId  = account.id;
+            input.dataset.isLiability = account.is_liability;
+            input.value = lastBalance;
+            input.placeholder = 'Enter balance';
+
+            const currencyEl = document.createElement('span');
+            currencyEl.className = 'refresh-account-currency';
+            currencyEl.textContent = account.currency;
+
+            inputGroup.appendChild(input);
+            inputGroup.appendChild(currencyEl);
+            item.appendChild(nameEl);
+            item.appendChild(currentEl);
+            item.appendChild(inputGroup);
+            body.appendChild(item);
+        });
+
+        if (hasLiabilities) {
+            const help = document.createElement('div');
+            help.className = 'refresh-liability-help';
+            help.innerHTML = 'ℹ️ <strong>Liability accounts:</strong> Enter positive numbers (e.g. 15606.10). They will be saved as negative automatically.';
+            body.appendChild(help);
+        }
+
+        modal.classList.add('show');
+    }
+
+    function _cancelModal() {
+        document.getElementById(MODAL_ID).classList.remove('show');
+
+        // Still wait for Plaid and show success if it lands
+        if (_plaidPromise) {
+            _plaidPromise
+                .then(result => {
+                    if (result.success) { _showSuccess(result); _reloadFn?.(); }
+                })
+                .catch(err => console.error('Plaid refresh error:', err));
+        }
+
+        if (_triggerBtn) _restoreButton(_triggerBtn._originalLabel ?? '🔄 Refresh');
+    }
+
+    // ─── Save handler ───────────────────────────────────────────────────────
+
+    window.saveRefreshBalances = async function () {
+        const saveBtn   = document.getElementById('saveRefreshModalBtn');
+        const cancelBtn = document.getElementById('cancelRefreshModalBtn');
+
+        saveBtn.disabled   = true;
+        cancelBtn.disabled = true;
+
+        const inputs = document.querySelectorAll(`#${MODAL_ID} .refresh-account-input`);
+        const manualBalances = {};
+
+        inputs.forEach(input => {
+            const val = input.value.trim();
+            if (val !== '') manualBalances[input.dataset.accountId] = val;
+        });
+
+        try {
+            // Wait for Plaid to finish first
+            saveBtn.textContent = 'Waiting for Plaid...';
+            const plaidResult = await _plaidPromise;
+
+            if (!plaidResult.success) {
+                alert('❌ Plaid refresh failed. Manual balances not saved.');
+                saveBtn.disabled   = false;
+                cancelBtn.disabled = false;
+                saveBtn.textContent = 'Save Balances';
+                return;
+            }
+
+            // Save manual balances
+            saveBtn.textContent = 'Saving...';
+            const res = await fetch('/api/refresh_balances', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ manualBalances }),
+            });
+            const result = await res.json();
+
+            if (result.success) {
+                document.getElementById(MODAL_ID).classList.remove('show');
+                _showSuccess({
+                    success: true,
+                    accountsUpdated: plaidResult.accountsUpdated + result.manualAccountsUpdated,
+                    date: result.date,
+                    exchangeRate: result.exchangeRate,
+                });
+                _reloadFn?.();
+            } else {
+                alert('❌ Failed to save manual balances.');
+                saveBtn.disabled   = false;
+                cancelBtn.disabled = false;
+                saveBtn.textContent = 'Save Balances';
+            }
+        } catch (err) {
+            alert('❌ Error: ' + err.message);
+            saveBtn.disabled   = false;
+            cancelBtn.disabled = false;
+            saveBtn.textContent = 'Save Balances';
+        } finally {
+            cancelBtn.disabled = false;
+            if (_triggerBtn) _restoreButton(_triggerBtn._originalLabel ?? '🔄 Refresh');
+        }
+    };
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    function _restoreButton(label) {
+        if (_triggerBtn) {
+            _triggerBtn.disabled    = false;
+            _triggerBtn.textContent = label;
+        }
+    }
+
+    function _showSuccess(result) {
+        alert(
+            `✅ Successfully refreshed ${result.accountsUpdated} accounts!\n\n` +
+            `Date: ${result.date}\n` +
+            `Exchange Rate: ${parseFloat(result.exchangeRate).toFixed(4)}`
+        );
+    }
+
+    function _formatCurrency(amount, currency = 'CAD') {
+        return new Intl.NumberFormat('en-CA', {
+            style: 'currency',
+            currency,
+            minimumFractionDigits: 2,
+        }).format(amount);
+    }
+})();

--- a/public/js/retirement.js
+++ b/public/js/retirement.js
@@ -472,142 +472,20 @@ async function saveNewAccount() {
     }
 }
 
-// ─── Update Balances modal ─────────────────────────────────────────────────
-
-async function showUpdateBalancesModal() {
-    const body = document.getElementById('updateBalancesBody');
-    body.innerHTML = '<p style="color:#7f8c8d;padding:8px 0;">Loading accounts…</p>';
-
-    const btn = document.getElementById('saveUpdateBalancesBtn');
-    btn.disabled = false;
-    btn.textContent = 'Save Balances';
-
-    document.getElementById('updateBalancesModal').classList.add('show');
-
-    try {
-        const res = await fetch('/api/manual_accounts?category=retirement');
-        if (!res.ok) throw new Error('Failed to load accounts');
-        const accounts = await res.json();
-
-        if (!accounts.length) {
-            body.innerHTML = '<p style="color:#7f8c8d;">No manual accounts yet. Use <strong>＋ Add Account</strong> to get started.</p>';
-            btn.disabled = true;
-            return;
-        }
-
-        body.innerHTML = '';
-        accounts.forEach(account => {
-            const currentBalance = account.last_balance !== null && account.last_balance !== undefined
-                ? parseFloat(account.last_balance)
-                : '';
-
-            const item = document.createElement('div');
-            item.className = 'update-account-item';
-
-            const nameEl = document.createElement('div');
-            nameEl.className = 'update-account-name';
-            nameEl.textContent = account.account_name;
-
-            const metaEl = document.createElement('div');
-            metaEl.className = 'update-account-meta';
-            metaEl.textContent = `${account.institution_name} · ${typeLabel(account.account_type)}`;
-
-            const inputGroup = document.createElement('div');
-            inputGroup.className = 'update-account-input-group';
-
-            const input = document.createElement('input');
-            input.type = 'number';
-            input.className = 'update-account-input';
-            input.dataset.accountId = account.id;
-            input.value = currentBalance;
-            input.placeholder = 'Enter balance';
-            input.step = '0.01';
-            input.min = '0';
-
-            const currencyLabel = document.createElement('span');
-            currencyLabel.className = 'update-account-currency';
-            currencyLabel.textContent = account.currency;
-
-            inputGroup.appendChild(input);
-            inputGroup.appendChild(currencyLabel);
-            item.appendChild(nameEl);
-            item.appendChild(metaEl);
-            item.appendChild(inputGroup);
-            body.appendChild(item);
-        });
-    } catch (err) {
-        body.innerHTML = `<p style="color:#e74c3c;">Failed to load accounts: ${err.message}</p>`;
-        btn.disabled = true;
-    }
-}
-
-function closeUpdateBalancesModal() {
-    document.getElementById('updateBalancesModal').classList.remove('show');
-}
-
-async function saveRetirementBalances() {
-    const inputs = document.querySelectorAll('#updateBalancesBody .update-account-input');
-    const manualBalances = {};
-    let hasError = false;
-
-    inputs.forEach(input => {
-        const val = input.value.trim();
-        if (val === '') return; // Skip blank inputs
-        const num = parseFloat(val);
-        if (isNaN(num)) {
-            input.style.borderColor = '#e74c3c';
-            hasError = true;
-        } else {
-            input.style.borderColor = '';
-            manualBalances[input.dataset.accountId] = num;
-        }
-    });
-
-    if (hasError) return;
-    if (!Object.keys(manualBalances).length) {
-        closeUpdateBalancesModal();
-        return;
-    }
-
-    const btn = document.getElementById('saveUpdateBalancesBtn');
-    btn.disabled = true;
-    btn.textContent = 'Saving…';
-
-    try {
-        const res = await fetch('/api/refresh_balances', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ manualBalances }),
-        });
-        if (!res.ok) {
-            const data = await res.json();
-            throw new Error(data.error || 'Failed to save balances');
-        }
-
-        closeUpdateBalancesModal();
-        await loadRetirementDashboard();
-    } catch (err) {
-        btn.disabled = false;
-        btn.textContent = 'Save Balances';
-        // Show error inline above footer
-        const body = document.getElementById('updateBalancesBody');
-        let errEl = document.getElementById('updateBalancesError');
-        if (!errEl) {
-            errEl = document.createElement('div');
-            errEl.id = 'updateBalancesError';
-            errEl.style.cssText = 'background:#fdf0f0;border-left:4px solid #e74c3c;padding:10px 14px;border-radius:4px;color:#c0392b;font-size:0.9rem;margin-bottom:16px;';
-            body.prepend(errEl);
-        }
-        errEl.textContent = err.message || 'Something went wrong. Please try again.';
-    }
-}
 
 // ─── Modal event listeners (called on DOMContentLoaded) ────────────────────
 
 function setupModalEventListeners() {
     // Panel action buttons
     document.getElementById('addAccountBtn').addEventListener('click', showAddAccountModal);
-    document.getElementById('updateBalancesBtn').addEventListener('click', showUpdateBalancesModal);
+
+    // Refresh buttons — delegate to shared triggerRefresh() from refresh-modal.js
+    document.getElementById('refreshRetirementBtn').addEventListener('click', function () {
+        triggerRefresh('retirement', this, loadRetirementDashboard);
+    });
+    document.getElementById('refreshAllBtn').addEventListener('click', function () {
+        triggerRefresh(null, this, loadRetirementDashboard);
+    });
 
     // Add Account modal
     document.getElementById('closeAddAccountBtn').addEventListener('click', closeAddAccountModal);
@@ -617,19 +495,11 @@ function setupModalEventListeners() {
         if (e.target === this) closeAddAccountModal();
     });
 
-    // Update Balances modal
-    document.getElementById('closeUpdateBalancesBtn').addEventListener('click', closeUpdateBalancesModal);
-    document.getElementById('cancelUpdateBalancesBtn').addEventListener('click', closeUpdateBalancesModal);
-    document.getElementById('saveUpdateBalancesBtn').addEventListener('click', saveRetirementBalances);
-    document.getElementById('updateBalancesModal').addEventListener('click', function (e) {
-        if (e.target === this) closeUpdateBalancesModal();
-    });
-
-    // Escape key closes whichever modal is open
+    // Escape key closes Add Account modal (refresh modal handles its own Escape)
     document.addEventListener('keydown', function (e) {
-        if (e.key !== 'Escape') return;
-        if (document.getElementById('addAccountModal').classList.contains('show')) closeAddAccountModal();
-        if (document.getElementById('updateBalancesModal').classList.contains('show')) closeUpdateBalancesModal();
+        if (e.key === 'Escape' && document.getElementById('addAccountModal').classList.contains('show')) {
+            closeAddAccountModal();
+        }
     });
 }
 

--- a/public/retirement.html
+++ b/public/retirement.html
@@ -35,12 +35,49 @@
             font-size: 2rem;
         }
 
-        /* ── Page tabs (shared with index.html) ─────────────────────────── */
-        .page-tabs {
+        /* ── Tab row with global refresh button ─────────────────────────── */
+        .page-tabs-row {
             display: flex;
-            gap: 8px;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
             margin-bottom: 30px;
         }
+
+        .page-tabs-row .tabs-left {
+            display: flex;
+            gap: 8px;
+        }
+
+        .btn-refresh-all {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            padding: 10px 18px;
+            border-radius: 8px;
+            cursor: pointer;
+            font-size: 0.9rem;
+            font-weight: 600;
+            transition: opacity 0.2s;
+            white-space: nowrap;
+        }
+        .btn-refresh-all:hover    { opacity: 0.9; }
+        .btn-refresh-all:disabled { opacity: 0.6; cursor: not-allowed; }
+
+        .btn-panel-action {
+            padding: 8px 14px;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            cursor: pointer;
+            background: white;
+            color: #2c3e50;
+            transition: background 0.2s;
+            white-space: nowrap;
+        }
+        .btn-panel-action:hover    { background: #f0f0f0; }
+        .btn-panel-action:disabled { opacity: 0.6; cursor: not-allowed; }
 
         .tab-link {
             padding: 10px 20px;
@@ -607,9 +644,12 @@
     <div class="container">
         <h1>🏦 Retirement Accounts</h1>
 
-        <div class="page-tabs">
-            <a href="/index.html" class="tab-link">💵 Liquid Cash</a>
-            <a href="/retirement.html" class="tab-link active">🏦 Retirement</a>
+        <div class="page-tabs-row">
+            <div class="tabs-left">
+                <a href="/index.html" class="tab-link">💵 Liquid Cash</a>
+                <a href="/retirement.html" class="tab-link active">🏦 Retirement</a>
+            </div>
+            <button class="btn-refresh-all" id="refreshAllBtn">🔄 Refresh All Balances</button>
         </div>
 
         <!-- Summary cards — populated dynamically by retirement.js -->
@@ -625,8 +665,8 @@
             <div class="balances-panel-header">
                 <h2>Retirement Account Balances <span></span></h2>
                 <div class="balances-panel-actions">
-                    <button class="panel-action-btn secondary" id="updateBalancesBtn">✏️ Update Balances</button>
-                    <button class="panel-action-btn primary" id="addAccountBtn">＋ Add Account</button>
+                    <button class="btn-panel-action" id="addAccountBtn">➕ Add Manual Account</button>
+                    <button class="btn-panel-action" id="refreshRetirementBtn">🔄 Refresh Retirement Balances</button>
                 </div>
             </div>
         </div>
@@ -688,24 +728,6 @@
             </div>
         </div>
 
-        <!-- Update Balances modal -->
-        <div class="ret-modal" id="updateBalancesModal">
-            <div class="ret-modal-content">
-                <div class="ret-modal-header">
-                    <button class="ret-modal-close" id="closeUpdateBalancesBtn">×</button>
-                    <h2>✏️ Update Retirement Balances</h2>
-                    <p>Enter current balances for your manual accounts</p>
-                </div>
-                <div class="ret-modal-body" id="updateBalancesBody">
-                    <!-- Populated dynamically -->
-                </div>
-                <div class="ret-modal-footer">
-                    <button class="ret-modal-btn cancel" id="cancelUpdateBalancesBtn">Cancel</button>
-                    <button class="ret-modal-btn save" id="saveUpdateBalancesBtn">Save Balances</button>
-                </div>
-            </div>
-        </div>
-
         <!-- Trend chart -->
         <div class="chart-panel">
             <h2>Retirement Trend (CAD)</h2>
@@ -722,6 +744,7 @@
         </div>
     </div>
 
+    <script src="/js/refresh-modal.js"></script>
     <script src="/js/retirement.js"></script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -1300,7 +1300,7 @@ app.post('/api/exchange_public_token', async (req, res) => {
 // Refresh balances from Plaid and save to database.
 // Called directly by the EventBridge scheduler (via lambda.js) and by the
 // HTTP route below. Returns a result object; throws on error.
-async function refreshBalances({ manualBalances = {}, date = null } = {}) {
+async function refreshBalances({ manualBalances = {}, date = null, category = null } = {}) {
     // Get current exchange rate (with auto-refresh if stale)
     const exchangeRateResult = await pool.query(`
       SELECT rate, updated_at FROM exchange_rates
@@ -1379,13 +1379,20 @@ async function refreshBalances({ manualBalances = {}, date = null } = {}) {
           console.log(`   - Account: ${account.name}, Balance: ${account.balances.current}, Plaid ID: ${account.account_id}`);
 
           const accountResult = await pool.query(`
-            SELECT id, account_name, account_type, is_liability FROM accounts WHERE plaid_account_id = $1
+            SELECT id, account_name, account_type, account_category, is_liability FROM accounts WHERE plaid_account_id = $1
           `, [account.account_id]);
 
           if (accountResult.rows.length > 0) {
             const accountId = accountResult.rows[0].id;
             const accountName = accountResult.rows[0].account_name;
             const accountType = accountResult.rows[0].account_type;
+            const accountCategory = accountResult.rows[0].account_category;
+
+            // Skip this account if a category filter is active and it doesn't match
+            if (category && accountCategory !== category) {
+              console.log(`     ⏭️  Skipping ${accountName} (${accountCategory}, filter=${category})`);
+              continue;
+            }
 
             let balanceToSave = account.balances.current;
 
@@ -1489,12 +1496,17 @@ async function refreshBalances({ manualBalances = {}, date = null } = {}) {
     };
 }
 
-// Refresh balances from Plaid and save to database
+// Refresh balances from Plaid and save to database.
+// Optional body params:
+//   category     – 'liquid' | 'retirement' (omit for all)
+//   manualBalances – { accountId: balance } map for manual-only save pass
+//   date         – override today's date (used by scheduler)
 app.post('/api/refresh_balances', async (req, res) => {
   try {
     const result = await refreshBalances({
       manualBalances: req.body?.manualBalances,
       date: req.body?.date,
+      category: req.body?.category,
     });
     res.json(result);
   } catch (error) {


### PR DESCRIPTION
## Summary

- Replaces the single "Refresh Balances" button with three scoped buttons, all following the same UX flow (Plaid in background + manual accounts modal):
  - **🔄 Refresh All Balances** — in the tab row on both pages; refreshes all Plaid accounts + all manual accounts
  - **🔄 Refresh Cash Balances** — in the Liquid Cash balances panel; scoped to liquid accounts only
  - **🔄 Refresh Retirement Balances** — in the Retirement balances panel; scoped to retirement accounts only (replaces the old Update Balances button, now with full Plaid support)
- New public/js/refresh-modal.js shared module provides triggerRefresh(category, btn, reloadFn) — eliminates code duplication between pages
- Backend POST /api/refresh_balances accepts optional category param to filter which Plaid accounts are refreshed
- Renames Add Account to Add Manual Account on the Retirement page

## Test plan

- [x] npm start, log in
- [x] Liquid Cash page: click Refresh All Balances — Plaid fires, manual modal shows all manual accounts
- [x] Liquid Cash page: click Refresh Cash Balances — only liquid Plaid accounts refresh, modal shows only liquid manual accounts
- [x] Retirement page: click Refresh All Balances — same as above (all scope)
- [x] Retirement page: click Refresh Retirement Balances — only retirement Plaid accounts refresh, modal shows only retirement manual accounts
- [x] With no manual accounts: clicking any refresh button skips modal, shows success alert
- [x] Cancel on manual modal: Plaid result still shown in success alert, page reloads
- [x] Escape key closes the manual modal
- [x] Add Manual Account button on Retirement page still opens the Add Account form correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)