### PR TITLE
Add manual account creation for Liquid Cash page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -210,11 +210,6 @@
             font-weight: 500;
         }
 
-        .account-name.old {
-            color: #95a5a6;
-            font-style: italic;
-        }
-
         .account-type {
             color: #7f8c8d;
             font-size: 0.9rem;
@@ -683,6 +678,131 @@
             color: white;
             border-color: transparent;
         }
+
+        /* ── Add Liquid Account modal ──────────────────────────────────────── */
+        .liq-modal {
+            position: fixed;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background: rgba(0, 0, 0, 0.5);
+            z-index: 2000;
+            display: none;
+            justify-content: center;
+            align-items: center;
+            padding: 20px;
+        }
+        .liq-modal.show { display: flex; }
+
+        .liq-modal-content {
+            background: white;
+            border-radius: 16px;
+            max-width: 560px;
+            width: 100%;
+            max-height: 85vh;
+            display: flex;
+            flex-direction: column;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+        }
+
+        .liq-modal-header {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 24px;
+            border-radius: 16px 16px 0 0;
+            position: relative;
+        }
+        .liq-modal-header h2 { margin: 0; font-size: 1.4rem; }
+        .liq-modal-header p  { margin: 6px 0 0; opacity: 0.9; font-size: 0.9rem; }
+
+        .liq-modal-close {
+            position: absolute;
+            top: 20px; right: 20px;
+            background: rgba(255,255,255,0.2);
+            border: none;
+            color: white;
+            width: 32px; height: 32px;
+            border-radius: 50%;
+            font-size: 1.3rem;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            line-height: 1;
+        }
+        .liq-modal-close:hover { background: rgba(255,255,255,0.3); }
+
+        .liq-modal-body {
+            padding: 24px;
+            overflow-y: auto;
+            flex: 1;
+        }
+
+        .liq-modal-footer {
+            padding: 20px 24px;
+            border-top: 1px solid #e0e0e0;
+            display: flex;
+            gap: 12px;
+            justify-content: flex-end;
+        }
+
+        .liq-modal-btn {
+            padding: 10px 24px;
+            border: none;
+            border-radius: 6px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        .liq-modal-btn.cancel       { background: #f8f9fa; color: #2c3e50; }
+        .liq-modal-btn.cancel:hover { background: #e9ecef; }
+        .liq-modal-btn.save         { background: #667eea; color: white; }
+        .liq-modal-btn.save:hover   { background: #5568d3; }
+        .liq-modal-btn:disabled     { background: #95a5a6; cursor: not-allowed; opacity: 0.7; }
+
+        .liq-modal-error {
+            background: #fdf0f0;
+            border-left: 4px solid #e74c3c;
+            padding: 10px 14px;
+            border-radius: 4px;
+            color: #c0392b;
+            font-size: 0.9rem;
+            margin-bottom: 16px;
+            display: none;
+        }
+
+        .liq-form-field { margin-bottom: 20px; }
+        .liq-form-field label {
+            display: block;
+            font-weight: 600;
+            color: #2c3e50;
+            margin-bottom: 6px;
+            font-size: 0.9rem;
+        }
+        .liq-form-field input,
+        .liq-form-field select {
+            width: 100%;
+            padding: 10px 12px;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            font-size: 1rem;
+            font-family: inherit;
+            color: #2c3e50;
+            background: white;
+            transition: border-color 0.2s;
+        }
+        .liq-form-field input:focus,
+        .liq-form-field select:focus { outline: none; border-color: #667eea; }
+        .liq-form-field input[type="number"] { font-family: monospace; }
+        .liq-form-field .field-hint {
+            margin-top: 4px;
+            font-size: 0.8rem;
+            color: #95a5a6;
+        }
+        .liq-form-row {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+        }
     </style>
 </head>
 <body>
@@ -733,6 +853,7 @@
             <div class="balances-panel-header">
                 <h2>Current Account Balances <span id="balancesDateNote" style="color:#7f8c8d;font-size:0.9rem;font-weight:normal;">Loading...</span></h2>
                 <div class="balances-panel-actions">
+                    <button class="btn-panel-action" id="addLiquidAccountBtn">➕ Add Manual Account</button>
                     <button class="btn-panel-action" id="refreshCashBtn">🔄 Refresh Cash Balances</button>
                 </div>
             </div>
@@ -774,6 +895,55 @@
                         Loading...
                     </div>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Add Manual Account modal -->
+    <div class="liq-modal" id="addLiquidAccountModal">
+        <div class="liq-modal-content">
+            <div class="liq-modal-header">
+                <button class="liq-modal-close" id="closeLiqAddAccountBtn">×</button>
+                <h2>＋ Add Liquid Account</h2>
+                <p>Manually add an account not connected via Plaid</p>
+            </div>
+            <div class="liq-modal-body">
+                <div class="liq-modal-error" id="liqAddAccountError"></div>
+                <div class="liq-form-field">
+                    <label for="liqAddInstitution">Institution</label>
+                    <input type="text" id="liqAddInstitution" placeholder="e.g. TD Bank" autocomplete="organization">
+                </div>
+                <div class="liq-form-field">
+                    <label for="liqAddAccountName">Account Name</label>
+                    <input type="text" id="liqAddAccountName" placeholder="e.g. Everyday Chequing" autocomplete="off">
+                </div>
+                <div class="liq-form-row">
+                    <div class="liq-form-field">
+                        <label for="liqAddAccountType">Account Type</label>
+                        <select id="liqAddAccountType">
+                            <option value="checking" selected>Checking</option>
+                            <option value="savings">Savings</option>
+                            <option value="credit">Credit Card</option>
+                            <option value="loc">Line of Credit</option>
+                        </select>
+                    </div>
+                    <div class="liq-form-field">
+                        <label for="liqAddCurrency">Currency</label>
+                        <select id="liqAddCurrency">
+                            <option value="CAD">CAD</option>
+                            <option value="USD">USD</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="liq-form-field">
+                    <label for="liqAddInitialBalance">Initial Balance</label>
+                    <input type="number" id="liqAddInitialBalance" placeholder="Optional" step="0.01" min="0">
+                    <div class="field-hint">Leave blank to add with no balance history yet. For credit cards / lines of credit, enter a positive number — it will be stored as negative automatically.</div>
+                </div>
+            </div>
+            <div class="liq-modal-footer">
+                <button class="liq-modal-btn cancel" id="cancelLiqAddAccountBtn">Cancel</button>
+                <button class="liq-modal-btn save"   id="saveLiqAddAccountBtn">Save Account</button>
             </div>
         </div>
     </div>

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -24,6 +24,15 @@ function setupEventListeners() {
         triggerRefresh('liquid', this, loadDashboard);
     });
 
+    // Add Manual Account modal
+    document.getElementById('addLiquidAccountBtn').addEventListener('click', openAddLiquidAccountModal);
+    document.getElementById('closeLiqAddAccountBtn').addEventListener('click', closeAddLiquidAccountModal);
+    document.getElementById('cancelLiqAddAccountBtn').addEventListener('click', closeAddLiquidAccountModal);
+    document.getElementById('saveLiqAddAccountBtn').addEventListener('click', saveAddLiquidAccount);
+    document.getElementById('addLiquidAccountModal').addEventListener('click', function (e) {
+        if (e.target === this) closeAddLiquidAccountModal();
+    });
+
     // Date range buttons
     document.querySelectorAll('.date-range-btn').forEach(btn => {
         btn.addEventListener('click', function() {
@@ -46,10 +55,93 @@ function setupEventListeners() {
     // Close side panel button
     document.getElementById('closeSidePanelBtn').addEventListener('click', closeSidePanel);
 
-    // Escape key to close side panel (refresh modal handles its own Escape key)
+    // Escape key — close add-account modal first, then side panel
     document.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') closeSidePanel();
+        if (e.key === 'Escape') {
+            if (document.getElementById('addLiquidAccountModal').classList.contains('show')) {
+                closeAddLiquidAccountModal();
+            } else {
+                closeSidePanel();
+            }
+        }
     });
+}
+
+// ─── Add Liquid Account modal ───────────────────────────────────────────────
+
+function openAddLiquidAccountModal() {
+    document.getElementById('liqAddInstitution').value    = '';
+    document.getElementById('liqAddAccountName').value    = '';
+    document.getElementById('liqAddAccountType').value    = 'checking';
+    document.getElementById('liqAddCurrency').value       = 'CAD';
+    document.getElementById('liqAddInitialBalance').value = '';
+    _setLiqAddError('');
+
+    const btn = document.getElementById('saveLiqAddAccountBtn');
+    btn.disabled    = false;
+    btn.textContent = 'Save Account';
+
+    document.getElementById('addLiquidAccountModal').classList.add('show');
+    document.getElementById('liqAddInstitution').focus();
+}
+
+function closeAddLiquidAccountModal() {
+    document.getElementById('addLiquidAccountModal').classList.remove('show');
+}
+
+function _setLiqAddError(msg) {
+    const el = document.getElementById('liqAddAccountError');
+    el.textContent   = msg;
+    el.style.display = msg ? 'block' : 'none';
+}
+
+async function saveAddLiquidAccount() {
+    const institution_name  = document.getElementById('liqAddInstitution').value.trim();
+    const account_name      = document.getElementById('liqAddAccountName').value.trim();
+    const account_type      = document.getElementById('liqAddAccountType').value;
+    const currency          = document.getElementById('liqAddCurrency').value;
+    const initialBalanceRaw = document.getElementById('liqAddInitialBalance').value.trim();
+
+    if (!institution_name) { _setLiqAddError('Institution name is required.'); return; }
+    if (!account_name)     { _setLiqAddError('Account name is required.'); return; }
+
+    const initial_balance = initialBalanceRaw !== '' ? parseFloat(initialBalanceRaw) : undefined;
+    if (initialBalanceRaw !== '' && isNaN(initial_balance)) {
+        _setLiqAddError('Initial balance must be a valid number.');
+        return;
+    }
+
+    const btn = document.getElementById('saveLiqAddAccountBtn');
+    btn.disabled    = true;
+    btn.textContent = 'Saving…';
+    _setLiqAddError('');
+
+    try {
+        const res = await fetch('/api/accounts/manual', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                institution_name,
+                account_name,
+                account_type,
+                currency,
+                initial_balance,
+                account_category: 'liquid',
+            }),
+        });
+        const data = await res.json();
+
+        if (!res.ok) {
+            throw new Error(data.error || 'Failed to save account');
+        }
+
+        closeAddLiquidAccountModal();
+        await loadDashboard();
+    } catch (err) {
+        _setLiqAddError(err.message || 'Something went wrong. Please try again.');
+        btn.disabled    = false;
+        btn.textContent = 'Save Account';
+    }
 }
 
 async function loadDashboard() {
@@ -106,9 +198,6 @@ function updateSummaryCards(data) {
 }
 
 function updateAccountBalances(data) {
-    // Define old account IDs that need warning labels
-    const oldAccountIds = [5, 6, 7, 8, 14, 16];
-
     // Group accounts by type and currency
     const grouped = {};
     data.accounts.forEach(account => {
@@ -133,19 +222,9 @@ function updateAccountBalances(data) {
         grouped[sectionName].push(account);
     });
 
-    // Sort accounts within each section: new first, old last
+    // Sort accounts within each section by ID (server order)
     Object.keys(grouped).forEach(sectionName => {
-        grouped[sectionName].sort((a, b) => {
-            const aIsOld = oldAccountIds.includes(a.id);
-            const bIsOld = oldAccountIds.includes(b.id);
-
-            // Old accounts go to end
-            if (aIsOld && !bIsOld) return 1;
-            if (!aIsOld && bIsOld) return -1;
-
-            // Within same group (both old or both new), maintain original order by ID
-            return a.id - b.id;
-        });
+        grouped[sectionName].sort((a, b) => a.id - b.id);
     });
 
     const balancesPanel = document.querySelector('.balances-panel');
@@ -203,9 +282,8 @@ function updateAccountBalances(data) {
             accountRow.className = 'account-row';
             accountRow.onclick = function() { showHistory(account.id, account.account_name, account.currency, account.account_type); };
 
-            const isOld = oldAccountIds.includes(account.id);
-            const displayName = isOld ? '⚠️ Old - ' + account.account_name : account.account_name;
-            const nameClass = isOld ? 'account-name old' : 'account-name';
+            const displayName = account.account_name;
+            const nameClass = 'account-name';
 
             const balance = parseFloat(account.balance);
             const balanceClass = balance < 0 ? 'negative' : (balance > 0 ? 'positive' : '');

--- a/public/js/refresh-modal.js
+++ b/public/js/refresh-modal.js
@@ -156,7 +156,7 @@
         // Wire up close/cancel buttons and Escape key
         document.getElementById('closeRefreshModalBtn').addEventListener('click', _cancelModal);
         document.getElementById('cancelRefreshModalBtn').addEventListener('click', _cancelModal);
-        document.getElementById('saveRefreshModalBtn').addEventListener('click', saveRefreshBalances);
+        document.getElementById('saveRefreshModalBtn').addEventListener('click', () => saveRefreshBalances());
         modal.addEventListener('click', e => { if (e.target === modal) _cancelModal(); });
         document.addEventListener('keydown', e => {
             if (e.key === 'Escape' && modal.classList.contains('show')) _cancelModal();

--- a/server.js
+++ b/server.js
@@ -422,11 +422,11 @@ app.get('/api/manual_accounts', async (req, res) => {
   }
 });
 
-// Create a new manual retirement account (no Plaid connection).
+// Create a new manual account (liquid or retirement — no Plaid connection).
 // Optionally records an initial balance snapshot for today.
 app.post('/api/accounts/manual', async (req, res) => {
   try {
-    const { institution_name, account_name, account_type, currency, initial_balance } = req.body;
+    const { institution_name, account_name, account_type, currency, initial_balance, account_category } = req.body;
 
     if (!institution_name || !account_name || !account_type || !currency) {
       return res.status(400).json({ error: 'institution_name, account_name, account_type, and currency are required' });
@@ -436,16 +436,28 @@ app.post('/api/accounts/manual', async (req, res) => {
       return res.status(400).json({ error: 'currency must be CAD or USD' });
     }
 
+    const validCategories = ['liquid', 'retirement'];
+    const category = account_category || 'retirement';
+    if (!validCategories.includes(category)) {
+      return res.status(400).json({ error: 'account_category must be liquid or retirement' });
+    }
+
+    // Liability types — balances stored as negative; excluded from cash totals
+    const liabilityTypes = ['credit', 'credit card', 'loc', 'line of credit'];
+    const is_liability = liabilityTypes.includes(account_type.trim().toLowerCase());
+
     const accountResult = await pool.query(`
       INSERT INTO accounts
         (institution_name, account_name, account_type, account_category, currency, is_liability, is_active)
-      VALUES ($1, $2, $3, 'retirement', $4, false, true)
+      VALUES ($1, $2, $3, $4, $5, $6, true)
       RETURNING id, account_name, institution_name, account_type
     `, [
       institution_name.trim(),
       account_name.trim(),
       account_type.trim().toLowerCase(),
+      category,
       currency,
+      is_liability,
     ]);
 
     const account = accountResult.rows[0];
@@ -459,11 +471,14 @@ app.post('/api/accounts/manual', async (req, res) => {
       const rate = rateResult.rows.length > 0 ? parseFloat(rateResult.rows[0].rate) : null;
       const today = new Date().toISOString().split('T')[0];
 
+      // Liabilities are stored as negative values
+      const balanceToStore = is_liability ? -Math.abs(parsedBalance) : parsedBalance;
+
       await pool.query(`
         INSERT INTO balance_snapshots (account_id, balance, date, usd_to_cad_rate)
         VALUES ($1, $2, $3, $4)
         ON CONFLICT (account_id, date) DO UPDATE SET balance = $2, usd_to_cad_rate = $4
-      `, [account.id, parsedBalance, today, rate]);
+      `, [account.id, balanceToStore, today, rate]);
     }
 
     res.json({ success: true, account });


### PR DESCRIPTION
## Summary

- **Backend:** `POST /api/accounts/manual` now accepts `account_category` (`liquid` or `retirement`, defaults to `retirement` for backward compat). Computes `is_liability` from account type — credit card and line of credit are stored as negative. Initial balances for liabilities are automatically negated.
- **Liquid Cash page:** New "➕ Add Manual Account" button opens a form modal (institution, account name, type, currency, optional initial balance). Saving calls the updated endpoint and reloads the dashboard.
- **Bug fixes:**
  - `refresh-modal.js`: Fixed a latent `ReferenceError` — `saveRefreshBalances` was passed directly to `addEventListener` before it was assigned in the IIFE; wrapped in an arrow function to defer lookup to click time.
  - `dashboard.js`: Removed hardcoded `oldAccountIds = [5, 6, 7, 8, 14, 16]` that incorrectly labelled newly created accounts as "⚠️ Old" whenever their DB ID happened to match.

## Test plan

- [x] Click "➕ Add Manual Account" on the Liquid Cash page — modal opens, fields clear, Institution field is focused
- [x] Submit with missing Institution or Account Name — inline error shown, no request sent
- [x] Add a Checking account with an initial balance — account appears in the correct section, balance shows
- [x] Add a Credit Card with an initial balance — appears under CAD/USD Credit Cards, balance stored as negative
- [x] Add a Line of Credit with an initial balance — same as credit card behaviour
- [x] Add an account with no initial balance — account appears with no balance row
- [x] Click outside modal or press Escape — modal closes without saving
- [x] Verify "Refresh All Balances" and "Refresh Cash Balances" still work (IIFE bug fix)
- [x] Verify no accounts are incorrectly labelled "⚠️ Old"

🤖 Generated with [Claude Code](https://claude.com/claude-code)