### PR TITLE
Add dark mode with localStorage persistence

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -803,11 +803,127 @@
             grid-template-columns: 1fr 1fr;
             gap: 16px;
         }
+
+        /* ── Dark mode toggle button ───────────────────────────────────────── */
+        .btn-dark-mode {
+            background: none;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 6px 12px;
+            font-size: 1.1rem;
+            cursor: pointer;
+            color: #7f8c8d;
+            transition: background 0.2s, border-color 0.2s;
+            line-height: 1;
+        }
+        .btn-dark-mode:hover { background: #f0f0f0; }
+
+        /* ── Dark mode overrides ───────────────────────────────────────────── */
+        body.dark { background: #1a1d23; }
+        body.dark h1,
+        body.dark h2 { color: #e8eaf0; }
+        body.dark .card:not(.primary) {
+            background: #252930;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+        }
+        body.dark .card:not(.primary) .card-label { color: #9aa0b0; }
+        body.dark .card:not(.primary) .card-value { color: #e8eaf0; }
+        body.dark .balances-panel,
+        body.dark .chart-panel {
+            background: #252930;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+        }
+        body.dark .institution { border-color: #3a3f50; }
+        body.dark .institution-header { background: #2e3340; color: #e8eaf0; }
+        body.dark .institution-header:hover { background: #363c4a; }
+        body.dark .account-row { border-bottom-color: #2e3340; }
+        body.dark .account-row:hover { background: #2e3340; }
+        body.dark .account-name { color: #e8eaf0; }
+        body.dark .account-type { color: #9aa0b0; }
+        body.dark .liability-note {
+            background: #3a3520;
+            border-color: #c59400;
+            color: #d4a900;
+        }
+        body.dark .date-range-btn {
+            background: #2e3340;
+            border-color: #3a3f50;
+            color: #e8eaf0;
+        }
+        body.dark .date-range-btn:hover { background: #363c4a; }
+        body.dark .date-range-btn.active {
+            background: #667eea;
+            border-color: #667eea;
+            color: white;
+        }
+        body.dark .side-panel {
+            background: #252930;
+            box-shadow: -4px 0 20px rgba(0,0,0,0.4);
+        }
+        body.dark .history-chart-section h3,
+        body.dark .history-stats-section h3 { color: #e8eaf0; }
+        body.dark .history-chart-container,
+        body.dark .history-stats-section { background: #2e3340; }
+        body.dark .stats-row { color: #e8eaf0; }
+        body.dark .tab-link {
+            background: #252930;
+            border-color: #3a3f50;
+            color: #9aa0b0;
+            box-shadow: none;
+        }
+        body.dark .tab-link:hover { background: #363c4a; color: #e8eaf0; }
+        body.dark .btn-panel-action {
+            background: #252930;
+            border-color: #3a3f50;
+            color: #e8eaf0;
+        }
+        body.dark .btn-panel-action:hover { background: #363c4a; }
+        body.dark .btn-dark-mode { border-color: #3a3f50; color: #9aa0b0; }
+        body.dark .btn-dark-mode:hover { background: #2e3340; }
+        /* liq-modal dark mode */
+        body.dark .liq-modal-content { background: #252930; }
+        body.dark .liq-modal-footer { border-top-color: #3a3f50; }
+        body.dark .liq-modal-btn.cancel { background: #2e3340; color: #e8eaf0; }
+        body.dark .liq-modal-btn.cancel:hover { background: #363c4a; }
+        body.dark .liq-form-field label { color: #e8eaf0; }
+        body.dark .liq-form-field input,
+        body.dark .liq-form-field select {
+            background: #2e3340;
+            border-color: #3a3f50;
+            color: #e8eaf0;
+        }
+        body.dark .liq-form-field .field-hint { color: #7a8090; }
+        body.dark .liq-modal-error {
+            background: #3a2020;
+            border-color: #e74c3c;
+            color: #f17070;
+        }
+        /* refresh-modal dark mode */
+        body.dark .refresh-balance-content { background: #252930 !important; }
+        body.dark .refresh-balance-body    { background: #252930 !important; }
+        body.dark .refresh-account-name    { color: #e8eaf0 !important; }
+        body.dark .refresh-account-current { color: #9aa0b0 !important; }
+        body.dark .refresh-account-input {
+            background: #2e3340 !important;
+            border-color: #3a3f50 !important;
+            color: #e8eaf0 !important;
+        }
+        body.dark .refresh-account-currency { color: #9aa0b0 !important; }
+        body.dark .refresh-balance-footer {
+            border-top-color: #3a3f50 !important;
+            background: #252930 !important;
+        }
+        body.dark .refresh-balance-btn.cancel {
+            background: #2e3340 !important;
+            color: #e8eaf0 !important;
+        }
+        body.dark .refresh-account-item { border-bottom-color: #3a3f50 !important; }
     </style>
 </head>
 <body>
+    <script src="/js/dark-mode.js"></script>
     <div class="container">
-        <h1>💰 Financial Dashboard</h1>
+        <h1>💰 Financial Dashboard <button class="btn-dark-mode" id="darkModeToggleBtn" title="Toggle dark mode">🌙</button></h1>
 
         <div class="page-tabs-row">
             <div class="tabs-left">

--- a/public/js/dark-mode.js
+++ b/public/js/dark-mode.js
@@ -1,0 +1,47 @@
+// dark-mode.js — Shared dark mode utility.
+// Placed as the first <script> inside <body> so the class is applied before
+// the page renders, preventing a flash of the wrong theme.
+//
+// Exposes:
+//   window.toggleDarkMode()  — called by the toggle button on each page
+//   window.applyTheme(theme) — 'dark' | 'light'
+
+(function () {
+    const STORAGE_KEY = 'theme';
+    const DARK_CLASS  = 'dark';
+    const ICON_DARK   = '🌙';
+    const ICON_LIGHT  = '☀️';
+
+    // Apply the persisted theme immediately (before DOM is ready) to prevent FOUC
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === 'dark') {
+        document.body.classList.add(DARK_CLASS);
+    }
+
+    function _updateButtonIcon() {
+        const btn = document.getElementById('darkModeToggleBtn');
+        if (!btn) return;
+        const isDark = document.body.classList.contains(DARK_CLASS);
+        btn.textContent = isDark ? ICON_LIGHT : ICON_DARK;
+        btn.title = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+    }
+
+    window.applyTheme = function (theme) {
+        if (theme === 'dark') {
+            document.body.classList.add(DARK_CLASS);
+            localStorage.setItem(STORAGE_KEY, 'dark');
+        } else {
+            document.body.classList.remove(DARK_CLASS);
+            localStorage.setItem(STORAGE_KEY, 'light');
+        }
+        _updateButtonIcon();
+    };
+
+    window.toggleDarkMode = function () {
+        const isDark = document.body.classList.contains(DARK_CLASS);
+        window.applyTheme(isDark ? 'light' : 'dark');
+    };
+
+    // Once the DOM is ready, sync the button icon to the current state
+    document.addEventListener('DOMContentLoaded', _updateButtonIcon);
+})();

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -24,6 +24,11 @@ function setupEventListeners() {
         triggerRefresh('liquid', this, loadDashboard);
     });
 
+    // Dark mode toggle
+    document.getElementById('darkModeToggleBtn').addEventListener('click', function () {
+        if (typeof toggleDarkMode === 'function') toggleDarkMode();
+    });
+
     // Add Manual Account modal
     document.getElementById('addLiquidAccountBtn').addEventListener('click', openAddLiquidAccountModal);
     document.getElementById('closeLiqAddAccountBtn').addEventListener('click', closeAddLiquidAccountModal);

--- a/public/js/retirement.js
+++ b/public/js/retirement.js
@@ -476,6 +476,11 @@ async function saveNewAccount() {
 // ─── Modal event listeners (called on DOMContentLoaded) ────────────────────
 
 function setupModalEventListeners() {
+    // Dark mode toggle
+    document.getElementById('darkModeToggleBtn').addEventListener('click', function () {
+        if (typeof toggleDarkMode === 'function') toggleDarkMode();
+    });
+
     // Panel action buttons
     document.getElementById('addAccountBtn').addEventListener('click', showAddAccountModal);
 

--- a/public/retirement.html
+++ b/public/retirement.html
@@ -33,6 +33,9 @@
             color: #2c3e50;
             margin-bottom: 30px;
             font-size: 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
         }
 
         /* ── Tab row with global refresh button ─────────────────────────── */
@@ -638,11 +641,118 @@
                 display: none;
             }
         }
+
+        /* ── Dark mode toggle button ────────────────────────────────────── */
+        .btn-dark-mode {
+            background: none;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 6px 12px;
+            font-size: 1.1rem;
+            cursor: pointer;
+            color: #7f8c8d;
+            transition: background 0.2s, border-color 0.2s;
+            line-height: 1;
+        }
+        .btn-dark-mode:hover { background: #f0f0f0; }
+
+        /* ── Dark mode overrides ────────────────────────────────────────── */
+        body.dark { background: #1a1d23; }
+        body.dark h1 { color: #e8eaf0; }
+        body.dark .card:not(.primary) {
+            background: #252930;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+        }
+        body.dark .card:not(.primary) .card-label { color: #9aa0b0; }
+        body.dark .card:not(.primary) .card-value,
+        body.dark .card:not(.primary) .type-positive { color: #2ecc71 !important; }
+        body.dark .card:not(.primary) .card-sub { color: #9aa0b0; }
+        body.dark .balances-panel,
+        body.dark .chart-panel {
+            background: #252930;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+        }
+        body.dark .balances-panel-header h2 { color: #e8eaf0; }
+        body.dark .balances-panel-header h2 span { color: #9aa0b0; }
+        body.dark .chart-panel h2 { color: #e8eaf0; }
+        body.dark .institution { border-color: #3a3f50; }
+        body.dark .institution-header { background: #2e3340; color: #e8eaf0; }
+        body.dark .institution-header:hover { background: #363c4a; }
+        body.dark .account-row { border-bottom-color: #2e3340; }
+        body.dark .account-name { color: #e8eaf0; }
+        body.dark .account-type { color: #9aa0b0; }
+        body.dark .currency-note { color: #7a8090; }
+        body.dark .tag { background: #2e3340; color: #9aa0b0; }
+        body.dark .date-range-btn {
+            background: #2e3340;
+            border-color: #3a3f50;
+            color: #e8eaf0;
+        }
+        body.dark .date-range-btn:hover { background: #363c4a; }
+        body.dark .date-range-btn.active {
+            background: #667eea;
+            border-color: #667eea;
+            color: white;
+        }
+        body.dark .tab-link {
+            background: #252930;
+            border-color: #3a3f50;
+            color: #9aa0b0;
+            box-shadow: none;
+        }
+        body.dark .tab-link:hover { background: #363c4a; color: #e8eaf0; }
+        body.dark .btn-panel-action {
+            background: #252930;
+            border-color: #3a3f50;
+            color: #e8eaf0;
+        }
+        body.dark .btn-panel-action:hover { background: #363c4a; }
+        body.dark .btn-dark-mode { border-color: #3a3f50; color: #9aa0b0; }
+        body.dark .btn-dark-mode:hover { background: #2e3340; }
+        /* ret-modal dark mode */
+        body.dark .ret-modal-content { background: #252930; }
+        body.dark .ret-modal-footer { border-top-color: #3a3f50; }
+        body.dark .ret-modal-btn.cancel { background: #2e3340; color: #e8eaf0; }
+        body.dark .ret-modal-btn.cancel:hover { background: #363c4a; }
+        body.dark .form-field label { color: #e8eaf0; }
+        body.dark .form-field input,
+        body.dark .form-field select {
+            background: #2e3340;
+            border-color: #3a3f50;
+            color: #e8eaf0;
+        }
+        body.dark .form-field .field-hint { color: #7a8090; }
+        body.dark .ret-modal-error {
+            background: #3a2020;
+            border-color: #e74c3c;
+            color: #f17070;
+        }
+        /* refresh-modal dark mode */
+        body.dark .refresh-balance-content { background: #252930 !important; }
+        body.dark .refresh-balance-body    { background: #252930 !important; }
+        body.dark .refresh-account-name    { color: #e8eaf0 !important; }
+        body.dark .refresh-account-current { color: #9aa0b0 !important; }
+        body.dark .refresh-account-input {
+            background: #2e3340 !important;
+            border-color: #3a3f50 !important;
+            color: #e8eaf0 !important;
+        }
+        body.dark .refresh-account-currency { color: #9aa0b0 !important; }
+        body.dark .refresh-balance-footer {
+            border-top-color: #3a3f50 !important;
+            background: #252930 !important;
+        }
+        body.dark .refresh-balance-btn.cancel {
+            background: #2e3340 !important;
+            color: #e8eaf0 !important;
+        }
+        body.dark .refresh-account-item { border-bottom-color: #3a3f50 !important; }
     </style>
 </head>
 <body>
+    <script src="/js/dark-mode.js"></script>
     <div class="container">
-        <h1>🏦 Retirement Accounts</h1>
+        <h1>🏦 Retirement Accounts <button class="btn-dark-mode" id="darkModeToggleBtn" title="Toggle dark mode">🌙</button></h1>
 
         <div class="page-tabs-row">
             <div class="tabs-left">


### PR DESCRIPTION
## Summary

- **`public/js/dark-mode.js`** (new): Shared IIFE included as the first `<script>` in `<body>` on both pages. Reads `localStorage` on load and applies `body.dark` before the page renders — no flash of the wrong theme. Exposes `window.toggleDarkMode()` and `window.applyTheme('dark'|'light')`. Syncs the 🌙/☀️ button icon on `DOMContentLoaded`.
- **`index.html` + `retirement.html`**: Dark mode toggle button (🌙/☀️) added to h1. `body.dark` CSS override blocks cover all panels, cards, account rows, borders, buttons, the liq-modal / ret-modal add-account forms, and the dynamically-injected refresh-modal styles.
- **`dashboard.js` + `retirement.js`**: `darkModeToggleBtn` click wired to `toggleDarkMode()`. Preference persists across page navigations via `localStorage`.

## Test plan

- [x] Click 🌙 — switches to dark, button shows ☀️; click ☀️ — switches back
- [x] Hard-refresh in dark mode — page loads dark with no light flash
- [x] Navigate between Liquid Cash and Retirement tabs — theme follows
- [x] Dark mode visual check: summary cards, account rows, trend chart, side panel (Liquid Cash), account type badges (Retirement)
- [x] "➕ Add Manual Account" modal in dark mode — form fields and labels readable on both pages
- [x] Refresh Balances modal in dark mode — account inputs and buttons readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)