### PR TITLE
Fix refresh button label not restoring after refresh

### DIFF
--- a/public/js/refresh-modal.js
+++ b/public/js/refresh-modal.js
@@ -166,6 +166,7 @@
     // ─── Module state ───────────────────────────────────────────────────────
 
     let _triggerBtn   = null;   // button that started the refresh
+    let _triggerLabel = null;   // original label of that button, for restore
     let _reloadFn     = null;   // page-specific data reload function
     let _plaidPromise = null;   // background Plaid refresh promise
     let _plaidResult  = null;   // resolved Plaid result (stored for save step)
@@ -184,11 +185,11 @@
      * @param {Function}    reloadFn    Called after a successful save.
      */
     window.triggerRefresh = async function (category, triggerBtn, reloadFn) {
-        _triggerBtn  = triggerBtn;
-        _reloadFn    = reloadFn;
-        _plaidResult = null;
+        _triggerBtn   = triggerBtn;
+        _triggerLabel = triggerBtn.textContent;
+        _reloadFn     = reloadFn;
+        _plaidResult  = null;
 
-        const originalLabel = triggerBtn.textContent;
         triggerBtn.disabled = true;
         triggerBtn.textContent = '⏳ Refreshing...';
 
@@ -328,7 +329,7 @@
                 .catch(err => console.error('Plaid refresh error:', err));
         }
 
-        if (_triggerBtn) _restoreButton(_triggerBtn._originalLabel ?? '🔄 Refresh');
+        if (_triggerBtn) _restoreButton(_triggerLabel ?? '🔄 Refresh');
     }
 
     // ─── Save handler ───────────────────────────────────────────────────────
@@ -392,7 +393,7 @@
             saveBtn.textContent = 'Save Balances';
         } finally {
             cancelBtn.disabled = false;
-            if (_triggerBtn) _restoreButton(_triggerBtn._originalLabel ?? '🔄 Refresh');
+            if (_triggerBtn) _restoreButton(_triggerLabel ?? '🔄 Refresh');
         }
     };
 


### PR DESCRIPTION
## Summary

`triggerRefresh()` captured the original button label into a local variable `originalLabel` but never stored it anywhere accessible to the two restore call sites. Both called `_restoreButton(_triggerBtn._originalLabel ?? '🔄 Refresh')` — since `_originalLabel` was never set on the element, they always fell back to the hardcoded `'🔄 Refresh'`, overwriting labels like "Refresh All Balances" and "Refresh Cash Balances".

**Fix:** introduce a module-level `_triggerLabel` variable (alongside the existing `_triggerBtn`), assign it at the start of `triggerRefresh()`, and use it in both `_restoreButton()` calls.

## Test plan

- [ ] Click "Refresh All Balances" — button restores to "Refresh All Balances" after completion
- [ ] Click "Refresh Cash Balances" — restores to "Refresh Cash Balances"
- [ ] Click "Refresh Retirement Balances" — restores to "Refresh Retirement Balances"
- [ ] Cancel out of the manual balances modal — button still restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)