### PR TITLE
Switch to centralized ECR and two-role CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: sandbox
     permissions:
-      id-token: write  # Required for OIDC authentication to AWS
+      id-token: write
       contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials for ECR push
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ECR_PUSH_ROLE_ARN }}
           aws-region: us-west-2
 
       - name: Login to Amazon ECR
@@ -41,15 +41,19 @@ jobs:
             .
           docker push $ECR_REGISTRY/balance-tracker:$IMAGE_TAG
           docker push $ECR_REGISTRY/balance-tracker:latest
+          echo "IMAGE_URI=$ECR_REGISTRY/balance-tracker:$IMAGE_TAG" >> "$GITHUB_ENV"
+
+      - name: Configure AWS credentials for Lambda deploy
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-west-2
 
       - name: Deploy to Lambda
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
         run: |
           aws lambda update-function-code \
             --function-name balance-tracker-sandbox \
-            --image-uri $ECR_REGISTRY/balance-tracker:$IMAGE_TAG
+            --image-uri "$IMAGE_URI"
           aws lambda wait function-updated \
             --function-name balance-tracker-sandbox
 
@@ -59,17 +63,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: prd
     permissions:
-      id-token: write  # Required for OIDC authentication to AWS
+      id-token: write
       contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials for ECR push
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ECR_PUSH_ROLE_ARN }}
           aws-region: us-west-2
 
       - name: Login to Amazon ECR
@@ -87,14 +91,18 @@ jobs:
             .
           docker push $ECR_REGISTRY/balance-tracker:$IMAGE_TAG
           docker push $ECR_REGISTRY/balance-tracker:latest
+          echo "IMAGE_URI=$ECR_REGISTRY/balance-tracker:$IMAGE_TAG" >> "$GITHUB_ENV"
+
+      - name: Configure AWS credentials for Lambda deploy
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-west-2
 
       - name: Deploy to Lambda
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.ref_name }}
         run: |
           aws lambda update-function-code \
             --function-name balance-tracker-prd \
-            --image-uri $ECR_REGISTRY/balance-tracker:$IMAGE_TAG
+            --image-uri "$IMAGE_URI"
           aws lambda wait function-updated \
             --function-name balance-tracker-prd

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,3 +78,17 @@ Requires `.env` with: `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV`, `DATABASE_
 **Milestone 2:** COMPLETED: Database backup and restore is handled by `db_backup.sh`. Supports backing up localhost or production, and restoring production to localhost (with automatic pre-restore local snapshot). Credentials sourced from env files. Backups auto-pruned after 30 days. Sample data loadable via `npm run db:seed`. RLS enabled on Supabase via `db/enable_rls.sql`.
 
 **Milestone 3:** Deploy to AWS. I don't want to click to set up things in AWS except for in my sandbox where I might want to experiement. For all other environments I want to use Terraform to manage the deployments to AWS. I want to have at least one pre-production environment for my application and also one or more pre-production environments for my IaC.
+
+## Backlog
+
+**Pending promotion to production:**
+- Run `node migrations/010_add_account_category.js` against the production DB before or immediately after deploying the retirement feature. The migration is idempotent and safe to re-run.
+
+**Manual retirement account form:**
+- No UI exists yet for adding a manual (non-Plaid) retirement account. Currently requires using `npm run db:add-snapshot` directly. A form on `connect.html` or a dedicated page should include: account name, institution, account type (401k/IRA/RRSP/etc.), currency (CAD/USD), and category toggle (Liquid/Retirement).
+
+**Tests:**
+- No test framework is configured. First priorities when adding tests:
+  - Unit tests for retirement subtype auto-classification logic (server.js `RETIREMENT_SUBTYPES` set)
+  - Unit tests for the trend data carry-forward SQL CTE (or an integration test against a test DB)
+  - Auth middleware / session expiry behaviour

--- a/terraform/infra/ecr_data.tf
+++ b/terraform/infra/ecr_data.tf
@@ -1,3 +1,4 @@
-data "aws_ecr_repository" "app" {
-  name = var.app_name
+variable "ecr_repository_url" {
+  description = "ECR repository URL for the app image (from the central management account)"
+  type        = string
 }

--- a/terraform/infra/environments/prd.tfvars.example
+++ b/terraform/infra/environments/prd.tfvars.example
@@ -3,9 +3,10 @@
 
 # ── Deployment target ─────────────────────────────────────────────────────────
 
-environment     = "prd"
-aws_region      = "us-west-2"
-target_role_arn = "arn:aws:iam::<prd-account-id>:role/<role-name>"
+environment          = "prd"
+aws_region           = "us-west-2"
+target_role_arn      = "arn:aws:iam::<prd-account-id>:role/<role-name>"
+ecr_repository_url   = "<mgmt-account-id>.dkr.ecr.us-west-2.amazonaws.com/balance-tracker"
 
 # ── Application config ────────────────────────────────────────────────────────
 

--- a/terraform/infra/environments/sandbox.tfvars.example
+++ b/terraform/infra/environments/sandbox.tfvars.example
@@ -3,9 +3,10 @@
 
 # ── Deployment target ─────────────────────────────────────────────────────────
 
-environment     = "sandbox"
-aws_region      = "us-west-2"
-target_role_arn = "arn:aws:iam::<sandbox-account-id>:role/<role-name>"
+environment          = "sandbox"
+aws_region           = "us-west-2"
+target_role_arn      = "arn:aws:iam::<sandbox-account-id>:role/<role-name>"
+ecr_repository_url   = "<mgmt-account-id>.dkr.ecr.us-west-2.amazonaws.com/balance-tracker"
 
 # ── Application config ────────────────────────────────────────────────────────
 

--- a/terraform/infra/lambda.tf
+++ b/terraform/infra/lambda.tf
@@ -25,7 +25,7 @@ resource "aws_lambda_function" "app" {
   role          = aws_iam_role.lambda.arn
   package_type  = "Image"
 
-  image_uri = "${data.aws_ecr_repository.app.repository_url}:latest"
+  image_uri = "${var.ecr_repository_url}:latest"
 
   timeout     = 300
   memory_size = 512

--- a/terraform/infra/outputs.tf
+++ b/terraform/infra/outputs.tf
@@ -5,7 +5,7 @@ output "api_gateway_url" {
 
 output "ecr_repository_url" {
   description = "ECR repository URL for pushing container images"
-  value       = data.aws_ecr_repository.app.repository_url
+  value       = var.ecr_repository_url
 }
 
 output "lambda_function_name" {


### PR DESCRIPTION
## Summary

- Updates `deploy.yml` to use two IAM roles per job: `AWS_ECR_PUSH_ROLE_ARN` (management account) for ECR push, then re-configures with `AWS_DEPLOY_ROLE_ARN` (workload account) for Lambda deploy
- Replaces `data "aws_ecr_repository"` lookup in `ecr_data.tf` with `var.ecr_repository_url` — the central ECR URL from the management account; fixes a future breakage when old per-account ECR repos are removed
- Updates `lambda.tf` and `outputs.tf` to reference the new variable
- Updates tfvars example files with `ecr_repository_url` placeholder

## Prerequisites
- senilegenius/infrabase#3 must be merged and `terraform/mgmt` applied first
- `AWS_ECR_PUSH_ROLE_ARN` and `AWS_DEPLOY_ROLE_ARN` secrets must be set in both GitHub environments (already done)
- `ecr_repository_url` must be added to local `sandbox.tfvars` and `prd.tfvars`, then `terraform apply` run in both (already done)

## Test plan
- [ ] Merging to main triggers `deploy-sandbox` job
- [ ] ECR push step uses management account role and pushes to central ECR
- [ ] Lambda deploy step uses sandbox role and updates `balance-tracker-sandbox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)