### PR TITLE
Show native USD amount and CAD conversion on Liquid Cash page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -205,6 +205,15 @@
             border-bottom: none;
         }
 
+        .account-usd-note {
+            text-align: right;
+        }
+
+        .currency-note {
+            font-size: 0.8rem;
+            color: #95a5a6;
+        }
+
         .account-name {
             color: #2c3e50;
             font-weight: 500;
@@ -840,6 +849,7 @@
         body.dark .account-row:hover { background: #2e3340; }
         body.dark .account-name { color: #e8eaf0; }
         body.dark .account-type { color: #9aa0b0; }
+        body.dark .currency-note { color: #7a8090; }
         body.dark .liability-note {
             background: #3a3520;
             border-color: #c59400;

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -287,13 +287,24 @@ function updateAccountBalances(data) {
             accountRow.className = 'account-row';
             accountRow.onclick = function() { showHistory(account.id, account.account_name, account.currency, account.account_type); };
 
-            const displayName = account.account_name;
-            const nameClass = 'account-name';
-
             const balance = parseFloat(account.balance);
+            const rate = account.usd_to_cad_rate ? parseFloat(account.usd_to_cad_rate) : 1;
+            const balanceCad = account.currency === 'USD' ? balance * rate : balance;
             const balanceClass = balance < 0 ? 'negative' : (balance > 0 ? 'positive' : '');
 
-            accountRow.innerHTML = '<div><div class="' + nameClass + '">' + displayName + '</div><div class="account-type">' + account.institution_name + (account.account_mask ? ' • ' + account.account_mask : '') + '</div></div><div></div><div class="account-balance ' + balanceClass + '">' + formatCurrency(Math.abs(balance)) + '</div><div class="view-history">View History →</div>';
+            const usdNote = account.currency === 'USD'
+                ? `<span class="currency-note">${formatNative(balance, 'USD')} USD</span>`
+                : '';
+
+            accountRow.innerHTML = `
+                <div>
+                    <div class="account-name">${account.account_name}</div>
+                    <div class="account-type">${account.institution_name}${account.account_mask ? ' • ' + account.account_mask : ''}</div>
+                </div>
+                <div class="account-usd-note">${usdNote}</div>
+                <div class="account-balance ${balanceClass}">${formatCurrency(Math.abs(balanceCad))}</div>
+                <div class="view-history">View History →</div>
+            `;
 
             accountsDiv.appendChild(accountRow);
         });
@@ -510,6 +521,14 @@ function formatCurrency(value) {
         minimumFractionDigits: 2,
         maximumFractionDigits: 2
     });
+}
+
+function formatNative(amount, currency) {
+    return new Intl.NumberFormat('en-CA', {
+        style: 'currency',
+        currency: currency,
+        minimumFractionDigits: 2,
+    }).format(amount);
 }
 
 function formatDate(dateString) {

--- a/server.js
+++ b/server.js
@@ -501,9 +501,11 @@ app.get('/api/latest_balances', async (req, res) => {
         a.account_mask,
         a.is_liability,
         b.balance,
-        b.date
+        b.date,
+        er.rate AS usd_to_cad_rate
       FROM accounts a
       LEFT JOIN balance_snapshots b ON a.id = b.account_id
+      LEFT JOIN exchange_rates er ON er.from_currency = 'USD' AND er.to_currency = 'CAD'
       WHERE a.is_active = true
         AND a.account_category = 'liquid'
         AND b.balance IS NOT NULL


### PR DESCRIPTION
## Summary
- USD accounts on the Liquid Cash page now show their native USD amount (e.g. `US$1,234.56 USD`) in the second column, matching the existing Retirement page layout
- The balance column now displays the converted CAD total for USD accounts instead of the raw USD amount
- Adds `usd_to_cad_rate` to the `/api/latest_balances` response via an `exchange_rates` join

## Test plan
- [ ] Open the Liquid Cash page and verify USD checking/savings/credit accounts show a USD note in the second column
- [ ] Confirm the balance column shows the CAD-converted amount for USD accounts
- [ ] Confirm CAD accounts are unchanged (no USD note, balance unchanged)
- [ ] Check dark mode — USD note should render in muted grey
- [ ] Verify the Retirement page is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)