### PR TITLE
Upgrade Lambda base image from Node 20 to Node 24

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -2,7 +2,7 @@
 # includes the Lambda Runtime Interface Client (RIC).
 # For local Docker / App Runner use the existing Dockerfile instead.
 
-FROM public.ecr.aws/lambda/nodejs:20
+FROM public.ecr.aws/lambda/nodejs:24
 
 WORKDIR ${LAMBDA_TASK_ROOT}
 


### PR DESCRIPTION
## Summary

- Updates `Dockerfile.lambda` from `public.ecr.aws/lambda/nodejs:20` to `public.ecr.aws/lambda/nodejs:24`

This aligns the Lambda runtime with `Dockerfile` (already on `node:24-alpine`) and `package.json` which declares `"engines": { "node": ">=24.0.0" }`. Node 20 reaches end-of-life in April 2026.

## Test plan

- [ ] Confirm sandbox deploy succeeds after merge
- [ ] Smoke-test the app in sandbox before promoting to prd

🤖 Generated with [Claude Code](https://claude.com/claude-code)