### PR TITLE
Add integration test suite for security and data accuracy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,9 @@ gh pr create ...
 - `./db_backup.sh backup_prd` — Backup production database to `backups/` (uses `.env.production`)
 - `./db_backup.sh prd_to_localhost` — Snapshot local DB, then pull and restore production data locally
 
-No test framework is configured. No linter or formatter is configured.
+- `npm test` — Run the test suite (Node's built-in test runner + supertest). Automatically creates/resets the `balance_tracker_test` database first (`scripts/setup-test-db.sh`); requires local Postgres. Tests never touch the real database: `test/helpers/setup.js` pins `DATABASE_URL` to the test DB before `server.js` loads and refuses to run against a DB whose name doesn't contain "test".
+
+No linter or formatter is configured.
 
 ## Architecture
 
@@ -88,7 +90,8 @@ Requires `.env` with: `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV`, `DATABASE_
 - No UI exists yet for adding a manual (non-Plaid) retirement account. Currently requires using `npm run db:add-snapshot` directly. A form on `connect.html` or a dedicated page should include: account name, institution, account type (401k/IRA/RRSP/etc.), currency (CAD/USD), and category toggle (Liquid/Retirement).
 
 **Tests:**
-- No test framework is configured. First priorities when adding tests:
-  - Unit tests for retirement subtype auto-classification logic (server.js `RETIREMENT_SUBTYPES` set)
-  - Unit tests for the trend data carry-forward SQL CTE (or an integration test against a test DB)
-  - Auth middleware / session expiry behaviour
+- Integration test suite exists in `test/` (security + data accuracy, run via `npm test`). Remaining priorities:
+  - Unit tests for retirement subtype auto-classification (`RETIREMENT_SUBTYPES` in server.js) — requires extracting the logic or mocking Plaid's token exchange
+  - Plaid refresh flow (`refreshBalances` Plaid path) with a mocked Plaid client, including `ITEM_LOGIN_REQUIRED` handling
+  - Browser/UI tests with Playwright (login flow, dashboard renders totals, granularity toggle)
+  - Run tests in CI on PRs (GitHub Actions + Postgres service container)

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,9 @@
         "pg": "^8.21.0",
         "plaid": "^42.2.0"
       },
+      "devDependencies": {
+        "supertest": "^7.2.2"
+      },
       "engines": {
         "node": ">=24.0.0"
       }
@@ -33,6 +36,29 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@vendia/serverless-express": {
@@ -71,6 +97,13 @@
       "engines": {
         "node": ">= 6.0.0"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -178,6 +211,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/connect-pg-simple": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/connect-pg-simple/-/connect-pg-simple-10.0.0.tgz",
@@ -229,6 +272,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -286,6 +336,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -494,6 +555,13 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -570,6 +638,24 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -806,6 +892,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -1329,6 +1438,42 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/toidentifier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -604,16 +604,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -762,9 +762,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "db:add-bulk": "psql balance_tracker < db/add_snapshot.sql",
     "db:import-csv": "node db/import_csv.js",
     "create-user": "node db/create_user.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "pretest": "sh scripts/setup-test-db.sh",
+    "test": "node --test --test-concurrency=1 --test-force-exit 'test/*.test.js'",
     "migrate:account-19-to-34": "node migrations/007_migrate_account_19_to_34.js",
     "migrate:account-11-to-35": "node migrations/008_migrate_account_11_to_35.js",
     "db:migrate-category": "node migrations/010_add_account_category.js"
@@ -42,5 +43,8 @@
     "helmet": "^8.2.0",
     "pg": "^8.21.0",
     "plaid": "^42.2.0"
+  },
+  "devDependencies": {
+    "supertest": "^7.2.2"
   }
 }

--- a/scripts/setup-test-db.sh
+++ b/scripts/setup-test-db.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Create (if needed) and reset the dedicated test database.
+# Tests NEVER run against balance_tracker — only balance_tracker_test.
+set -e
+
+DB_NAME="${TEST_DB_NAME:-balance_tracker_test}"
+
+psql -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1 \
+  || createdb "${DB_NAME}"
+
+psql -q -d "${DB_NAME}" -f db/schema.sql

--- a/test/data-accuracy.test.js
+++ b/test/data-accuracy.test.js
@@ -1,0 +1,249 @@
+// Data accuracy tests: summary math, currency conversion, liability sign
+// handling, trend carry-forward, and liquid/retirement separation.
+//
+// Each describe block reseeds the database with a known fixture and asserts
+// exact expected numbers from the API.
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { app } = require('./helpers/setup');
+const db = require('./helpers/db');
+
+const pool = db.createPool();
+const RATE = 1.35;
+
+after(async () => {
+  await pool.end();
+});
+
+// Reseed the DB and return a logged-in agent (truncate wipes sessions too)
+async function freshLogin(ip) {
+  await db.seedUser(pool);
+  await db.seedExchangeRate(pool, RATE);
+  const agent = request.agent(app);
+  const res = await agent
+    .post('/api/login')
+    .set('X-Forwarded-For', ip)
+    .send(db.TEST_USER);
+  assert.equal(res.status, 200, 'test login failed');
+  return agent;
+}
+
+describe('summary math (liquid cash in CAD)', () => {
+  let agent;
+  const today = db.daysAgo(0);
+  const prior = db.daysAgo(5);
+
+  before(async () => {
+    await db.truncateAll(pool);
+    agent = await freshLogin('10.10.0.1');
+
+    const chequing = await db.seedAccount(pool, { name: 'Chequing', currency: 'CAD' });
+    const usdSavings = await db.seedAccount(pool, { name: 'US Savings', type: 'savings', currency: 'USD' });
+    const creditCard = await db.seedAccount(pool, { name: 'Visa', type: 'credit card', currency: 'CAD', isLiability: true });
+    const rrsp = await db.seedAccount(pool, { name: 'RRSP', type: 'rrsp', category: 'retirement', currency: 'CAD' });
+
+    // Prior snapshot: 900 + 500×1.35 − 100 = 1475 liquid CAD
+    await db.seedSnapshot(pool, chequing, 900, prior, RATE);
+    await db.seedSnapshot(pool, usdSavings, 500, prior, RATE);
+    await db.seedSnapshot(pool, creditCard, -100, prior, RATE);
+    await db.seedSnapshot(pool, rrsp, 9500, prior, RATE);
+
+    // Today: 1200 + 500×1.35 − 200 = 1675 liquid CAD
+    await db.seedSnapshot(pool, chequing, 1200, today, RATE);
+    await db.seedSnapshot(pool, usdSavings, 500, today, RATE);
+    await db.seedSnapshot(pool, creditCard, -200, today, RATE);
+    await db.seedSnapshot(pool, rrsp, 10000, today, RATE);
+  });
+
+  it('computes current totals, USD conversion, and credit card debt', async () => {
+    const res = await agent.get('/api/summary');
+    assert.equal(res.status, 200);
+
+    const s = res.body;
+    assert.equal(s.date, today);
+    assert.equal(s.totalCad, 1200);
+    assert.equal(s.totalUsd, 500);
+    assert.equal(s.ccDebtCad, 200);
+    assert.equal(s.ccDebtUsd, 0);
+    assert.equal(s.usdToCadRate, RATE);
+    // liquid = CAD + USD×rate − CC debt = 1200 + 675 − 200
+    assert.equal(s.liquidCashCad, 1675);
+  });
+
+  it('computes change vs the previous snapshot date', async () => {
+    const s = (await agent.get('/api/summary')).body;
+    assert.equal(s.previousDate, prior);
+    // 1675 − 1475
+    assert.equal(Math.round(s.liquidChange * 100) / 100, 200);
+  });
+
+  it('excludes retirement accounts from liquid balances', async () => {
+    const res = await agent.get('/api/latest_balances');
+    assert.equal(res.status, 200);
+    const names = res.body.accounts.map(a => a.account_name).sort();
+    assert.deepEqual(names, ['Chequing', 'US Savings', 'Visa']);
+  });
+
+  it('retirement summary converts USD and groups by type', async () => {
+    // Add a USD 401k so conversion is exercised: 10000 + 1000×1.35 = 11350
+    const k401 = await db.seedAccount(pool, { name: '401k', type: '401k', category: 'retirement', currency: 'USD' });
+    await db.seedSnapshot(pool, k401, 1000, today, RATE);
+
+    const res = await agent.get('/api/retirement_summary');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.totalRetirementCad, 11350);
+
+    const byType = Object.fromEntries(res.body.byType.map(t => [t.accountType, t.totalCad]));
+    assert.equal(byType['rrsp'], 10000);
+    assert.equal(byType['401k'], 1350);
+  });
+});
+
+describe('trend data carry-forward', () => {
+  let agent;
+
+  before(async () => {
+    await db.truncateAll(pool);
+    agent = await freshLogin('10.10.0.2');
+
+    // One CAD account with snapshots 6 days ago (100) and 2 days ago (250).
+    // The gap days must carry the last known balance forward.
+    const chequing = await db.seedAccount(pool, { name: 'Chequing', currency: 'CAD' });
+    await db.seedSnapshot(pool, chequing, 100, db.daysAgo(6), RATE);
+    await db.seedSnapshot(pool, chequing, 250, db.daysAgo(2), RATE);
+  });
+
+  it('fills every calendar day and carries balances forward', async () => {
+    const res = await agent.get('/api/trend_data?granularity=daily');
+    assert.equal(res.status, 200);
+
+    const rows = res.body;
+    assert.equal(rows.length, 7, 'should cover all 7 days from first snapshot to today');
+
+    const values = rows.map(r => parseFloat(r.liquid_cash_cad));
+    assert.deepEqual(values, [100, 100, 100, 100, 250, 250, 250]);
+
+    const dates = rows.map(r => r.date);
+    assert.equal(dates[0], db.daysAgo(6));
+    assert.equal(dates[6], db.daysAgo(0));
+  });
+
+  it('weekly granularity returns only Sundays plus today', async () => {
+    const res = await agent.get('/api/trend_data?granularity=weekly');
+    assert.equal(res.status, 200);
+
+    const today = db.daysAgo(0);
+    for (const row of res.body) {
+      const [y, m, d] = row.date.split('-').map(Number);
+      const dow = new Date(Date.UTC(y, m - 1, d)).getUTCDay();
+      assert.ok(dow === 0 || row.date === today, `${row.date} is neither a Sunday nor today`);
+    }
+    assert.equal(res.body.at(-1).date, today, 'today must always be included');
+  });
+
+  it('rejects an unknown granularity by falling back to daily', async () => {
+    const res = await agent.get('/api/trend_data?granularity=1;DROP TABLE accounts');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.length, 7);
+    const check = await pool.query('SELECT COUNT(*)::int AS n FROM accounts');
+    assert.equal(check.rows[0].n, 1, 'accounts table intact');
+  });
+
+  it('ignores inactive accounts', async () => {
+    const closed = await db.seedAccount(pool, { name: 'Closed', currency: 'CAD', isActive: false });
+    await db.seedSnapshot(pool, closed, 99999, db.daysAgo(1), RATE);
+
+    const res = await agent.get('/api/trend_data?granularity=daily');
+    const values = res.body.map(r => parseFloat(r.liquid_cash_cad));
+    assert.ok(values.every(v => v < 1000), 'inactive account balance leaked into trend');
+  });
+});
+
+describe('manual account creation and balance entry', () => {
+  let agent;
+
+  before(async () => {
+    await db.truncateAll(pool);
+    agent = await freshLogin('10.10.0.3');
+  });
+
+  it('rejects missing fields, bad currency, and bad category', async () => {
+    const cases = [
+      { account_name: 'No institution', account_type: 'savings', currency: 'CAD' },
+      { institution_name: 'B', account_name: 'X', account_type: 'savings', currency: 'EUR' },
+      { institution_name: 'B', account_name: 'X', account_type: 'savings', currency: 'CAD', account_category: 'crypto' },
+    ];
+    for (const body of cases) {
+      const res = await agent.post('/api/accounts/manual').send(body);
+      assert.equal(res.status, 400, `should reject: ${JSON.stringify(body)}`);
+    }
+  });
+
+  it('stores a credit card initial balance as negative (liability convention)', async () => {
+    const res = await agent.post('/api/accounts/manual').send({
+      institution_name: 'Test Bank',
+      account_name: 'Manual Visa',
+      account_type: 'credit card',
+      currency: 'CAD',
+      account_category: 'liquid',
+      initial_balance: 300,
+    });
+    assert.equal(res.status, 200);
+
+    const accounts = (await agent.get('/api/manual_accounts')).body;
+    const visa = accounts.find(a => a.account_name === 'Manual Visa');
+    assert.ok(visa, 'created account not found');
+    assert.equal(visa.is_liability, true);
+    assert.equal(parseFloat(visa.last_balance), -300);
+  });
+
+  it('defaults to the retirement category and supports category filtering', async () => {
+    const res = await agent.post('/api/accounts/manual').send({
+      institution_name: 'Test Bank',
+      account_name: 'Manual RRSP',
+      account_type: 'rrsp',
+      currency: 'CAD',
+      initial_balance: 5000,
+    });
+    assert.equal(res.status, 200);
+
+    const retirement = (await agent.get('/api/manual_accounts?category=retirement')).body;
+    assert.ok(retirement.some(a => a.account_name === 'Manual RRSP'));
+
+    const liquid = (await agent.get('/api/manual_accounts?category=liquid')).body;
+    assert.ok(!liquid.some(a => a.account_name === 'Manual RRSP'));
+  });
+
+  it('refresh_balances inverts positive entries for liability accounts', async () => {
+    const loan = await db.seedAccount(pool, {
+      name: 'Car Loan', type: 'loan', currency: 'CAD', isLiability: true,
+    });
+
+    // User enters 400 owed; it must be stored as −400
+    const res = await agent
+      .post('/api/refresh_balances')
+      .send({ manualBalances: { [loan]: 400 } });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.manualAccountsUpdated, 1);
+
+    const snap = await pool.query(
+      'SELECT balance FROM balance_snapshots WHERE account_id = $1', [loan]
+    );
+    assert.equal(parseFloat(snap.rows[0].balance), -400);
+  });
+
+  it('upserts rather than duplicates when the same day is saved twice', async () => {
+    const savings = await db.seedAccount(pool, { name: 'Upsert Test', type: 'savings', currency: 'CAD' });
+
+    await agent.post('/api/refresh_balances').send({ manualBalances: { [savings]: 100 } });
+    await agent.post('/api/refresh_balances').send({ manualBalances: { [savings]: 150 } });
+
+    const snaps = await pool.query(
+      'SELECT balance FROM balance_snapshots WHERE account_id = $1', [savings]
+    );
+    assert.equal(snaps.rows.length, 1, 'one snapshot per account per day');
+    assert.equal(parseFloat(snaps.rows[0].balance), 150);
+  });
+});

--- a/test/helpers/db.js
+++ b/test/helpers/db.js
@@ -1,0 +1,86 @@
+// Database helpers for tests: truncate tables and seed known fixtures.
+// Uses its own pool (same connection string as the app) so tests can
+// close it independently of the app's pool.
+const { Pool } = require('pg');
+const bcrypt = require('bcrypt');
+
+const TEST_USER = { username: 'testuser', password: 'correct-horse-battery-staple' };
+
+function createPool() {
+  return new Pool({ connectionString: process.env.DATABASE_URL });
+}
+
+async function truncateAll(pool) {
+  await pool.query(`
+    TRUNCATE balance_snapshots, accounts, plaid_items, exchange_rates, users, session
+    RESTART IDENTITY CASCADE
+  `);
+}
+
+async function seedUser(pool, { username, password } = TEST_USER) {
+  const hash = await bcrypt.hash(password, 10);
+  const result = await pool.query(
+    'INSERT INTO users (username, password_hash) VALUES ($1, $2) RETURNING id',
+    [username, hash]
+  );
+  return result.rows[0].id;
+}
+
+// updated_at defaults to NOW() so the app treats the rate as fresh and
+// never calls the external exchange-rate API during tests.
+async function seedExchangeRate(pool, rate = 1.35) {
+  await pool.query(
+    `INSERT INTO exchange_rates (from_currency, to_currency, rate, updated_at)
+     VALUES ('USD', 'CAD', $1, NOW())
+     ON CONFLICT (from_currency, to_currency) DO UPDATE SET rate = $1, updated_at = NOW()`,
+    [rate]
+  );
+}
+
+async function seedAccount(pool, {
+  institution = 'Test Bank',
+  name,
+  type = 'chequing',
+  category = 'liquid',
+  currency = 'CAD',
+  isLiability = false,
+  isActive = true,
+  plaidAccountId = null,
+}) {
+  const result = await pool.query(
+    `INSERT INTO accounts
+       (institution_name, account_name, account_type, account_category,
+        currency, is_liability, is_active, plaid_account_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id`,
+    [institution, name, type, category, currency, isLiability, isActive, plaidAccountId]
+  );
+  return result.rows[0].id;
+}
+
+async function seedSnapshot(pool, accountId, balance, date, rate = 1.35) {
+  await pool.query(
+    `INSERT INTO balance_snapshots (account_id, balance, date, usd_to_cad_rate)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (account_id, date) DO UPDATE SET balance = $2, usd_to_cad_rate = $4`,
+    [accountId, balance, date, rate]
+  );
+}
+
+// Matches how server.js computes "today" (new Date().toLocaleDateString('en-CA'))
+function daysAgo(n) {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toLocaleDateString('en-CA');
+}
+
+module.exports = {
+  TEST_USER,
+  createPool,
+  truncateAll,
+  seedUser,
+  seedExchangeRate,
+  seedAccount,
+  seedSnapshot,
+  daysAgo,
+};

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -1,0 +1,25 @@
+// Test environment bootstrap.
+//
+// This module MUST be required before server.js. It pins every required
+// environment variable to a test-safe value *before* dotenv runs — dotenv
+// never overrides variables that are already set, so values from .env
+// (real database, real Plaid credentials) can never leak into a test run.
+process.env.NODE_ENV = 'test';
+process.env.DATABASE_URL =
+  process.env.TEST_DATABASE_URL || 'postgresql://localhost/balance_tracker_test';
+process.env.SESSION_SECRET = 'test-session-secret';
+process.env.DB_ENCRYPTION_KEY = 'test-encryption-key';
+process.env.PLAID_CLIENT_ID = 'test-plaid-client-id';
+process.env.PLAID_SECRET = 'test-plaid-secret';
+process.env.PLAID_ENV = 'sandbox';
+process.env.ALLOWED_ORIGIN = 'http://localhost:3000';
+
+if (!process.env.DATABASE_URL.includes('test')) {
+  throw new Error(
+    `Refusing to run tests against non-test database: ${process.env.DATABASE_URL}`
+  );
+}
+
+const { app, refreshBalances } = require('../../server');
+
+module.exports = { app, refreshBalances };

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -1,0 +1,224 @@
+// Security tests: authentication, session handling, injection resistance,
+// rate limiting, and security headers.
+//
+// Note on X-Forwarded-For: the app sets `trust proxy`, and the login rate
+// limiter buckets by client IP. Each test group uses a distinct fake IP so
+// rate-limit state from one group can't bleed into another.
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { app } = require('./helpers/setup');
+const db = require('./helpers/db');
+
+const pool = db.createPool();
+
+before(async () => {
+  await db.truncateAll(pool);
+  await db.seedUser(pool);
+  await db.seedExchangeRate(pool);
+});
+
+after(async () => {
+  await pool.end();
+});
+
+describe('unauthenticated access is blocked', () => {
+  const protectedGets = [
+    '/api/exchange_rate',
+    '/api/accounts',
+    '/api/manual_accounts',
+    '/api/latest_balances',
+    '/api/historical_balances',
+    '/api/summary',
+    '/api/trend_data',
+    '/api/account_history/1',
+    '/api/retirement_balances',
+    '/api/retirement_summary',
+    '/api/retirement_trend_data',
+  ];
+
+  const protectedPosts = [
+    '/api/accounts/manual',
+    '/api/refresh_balances',
+    '/api/create_link_token',
+    '/api/create_link_token_update',
+    '/api/clear_item_error',
+    '/api/exchange_public_token',
+  ];
+
+  for (const path of protectedGets) {
+    it(`GET ${path} returns 401 without a session`, async () => {
+      const res = await request(app).get(path);
+      assert.equal(res.status, 401);
+    });
+  }
+
+  for (const path of protectedPosts) {
+    it(`POST ${path} returns 401 without a session`, async () => {
+      const res = await request(app).post(path).send({});
+      assert.equal(res.status, 401);
+    });
+  }
+
+  it('protected HTML pages redirect to login', async () => {
+    for (const page of ['/', '/index.html', '/connect.html']) {
+      const res = await request(app).get(page);
+      assert.equal(res.status, 302, `${page} should redirect`);
+      assert.equal(res.headers.location, '/login.html');
+    }
+  });
+
+  it('login page itself is reachable without a session', async () => {
+    const res = await request(app).get('/login.html');
+    assert.equal(res.status, 200);
+  });
+
+  it('/api/check-auth reports unauthenticated without leaking details', async () => {
+    const res = await request(app).get('/api/check-auth');
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body, { authenticated: false });
+  });
+});
+
+describe('login endpoint', () => {
+  it('requires both username and password', async () => {
+    const res = await request(app)
+      .post('/api/login')
+      .set('X-Forwarded-For', '10.1.0.1')
+      .send({ username: db.TEST_USER.username });
+    assert.equal(res.status, 400);
+  });
+
+  it('does not reveal whether the username or the password was wrong', async () => {
+    const unknownUser = await request(app)
+      .post('/api/login')
+      .set('X-Forwarded-For', '10.1.0.2')
+      .send({ username: 'no-such-user', password: 'whatever' });
+
+    const wrongPassword = await request(app)
+      .post('/api/login')
+      .set('X-Forwarded-For', '10.1.0.3')
+      .send({ username: db.TEST_USER.username, password: 'wrong-password' });
+
+    assert.equal(unknownUser.status, 401);
+    assert.equal(wrongPassword.status, 401);
+    // Identical responses prevent user enumeration
+    assert.deepEqual(unknownUser.body, wrongPassword.body);
+  });
+
+  it('is not vulnerable to SQL injection in the username', async () => {
+    const payloads = [
+      "' OR '1'='1",
+      "admin'--",
+      "'; DROP TABLE users; --",
+    ];
+
+    for (const payload of payloads) {
+      const res = await request(app)
+        .post('/api/login')
+        .set('X-Forwarded-For', '10.1.0.4')
+        .send({ username: payload, password: 'x' });
+      // Must be a clean rejection — not a 500 (SQL error) and not a login
+      assert.equal(res.status, 401, `payload should be rejected: ${payload}`);
+    }
+
+    // users table must still exist and still contain the seeded user
+    const users = await pool.query('SELECT COUNT(*)::int AS n FROM users');
+    assert.equal(users.rows[0].n, 1);
+  });
+
+  it('valid credentials log in and grant API access', async () => {
+    const agent = request.agent(app);
+
+    const login = await agent
+      .post('/api/login')
+      .set('X-Forwarded-For', '10.1.0.5')
+      .send(db.TEST_USER);
+    assert.equal(login.status, 200);
+    assert.equal(login.body.success, true);
+
+    const accounts = await agent.get('/api/accounts');
+    assert.equal(accounts.status, 200);
+  });
+
+  it('rate limits repeated login attempts from the same IP', async () => {
+    const attackerIp = '10.99.99.99';
+    let lastStatus;
+
+    for (let i = 0; i < 6; i++) {
+      const res = await request(app)
+        .post('/api/login')
+        .set('X-Forwarded-For', attackerIp)
+        .send({ username: db.TEST_USER.username, password: `guess-${i}` });
+      lastStatus = res.status;
+    }
+
+    assert.equal(lastStatus, 429, 'sixth attempt should be rate limited');
+  });
+});
+
+describe('session handling', () => {
+  it('session cookie is HttpOnly (not readable by page JavaScript)', async () => {
+    const res = await request(app)
+      .post('/api/login')
+      .set('X-Forwarded-For', '10.2.0.1')
+      .send(db.TEST_USER);
+
+    const cookie = res.headers['set-cookie']?.[0] ?? '';
+    assert.match(cookie, /HttpOnly/i);
+    assert.match(cookie, /Expires=/i, 'cookie should expire (idle timeout)');
+  });
+
+  it('logout destroys the session', async () => {
+    const agent = request.agent(app);
+    await agent
+      .post('/api/login')
+      .set('X-Forwarded-For', '10.2.0.2')
+      .send(db.TEST_USER);
+
+    // Sanity check: authenticated
+    assert.equal((await agent.get('/api/accounts')).status, 200);
+
+    const logout = await agent.post('/api/logout');
+    assert.equal(logout.status, 200);
+
+    // Session must be gone
+    assert.equal((await agent.get('/api/accounts')).status, 401);
+    const check = await agent.get('/api/check-auth');
+    assert.equal(check.body.authenticated, false);
+  });
+
+  it('a forged session cookie is rejected', async () => {
+    const res = await request(app)
+      .get('/api/accounts')
+      .set('Cookie', 'connect.sid=s%3Aforged-session-id.fakesignature');
+    assert.equal(res.status, 401);
+  });
+});
+
+describe('security headers', () => {
+  it('responses carry helmet security headers', async () => {
+    const res = await request(app).get('/login.html');
+
+    assert.ok(
+      res.headers['content-security-policy']?.includes("default-src 'self'"),
+      'CSP should restrict default sources to self'
+    );
+    assert.equal(res.headers['x-content-type-options'], 'nosniff');
+    assert.ok(res.headers['x-frame-options'], 'clickjacking protection missing');
+  });
+
+  it('input validation rejects a malformed account id', async () => {
+    const agent = request.agent(app);
+    await agent
+      .post('/api/login')
+      .set('X-Forwarded-For', '10.3.0.1')
+      .send(db.TEST_USER);
+
+    for (const bad of ['abc', '-1', '0']) {
+      const res = await agent.get(`/api/account_history/${bad}`);
+      assert.equal(res.status, 400, `account id "${bad}" should be rejected`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

First test foundation for the app, prioritized per the plan: **security first, data accuracy second** (UI tests are a documented follow-up). Uses Node's built-in test runner (`node --test`, no framework dependency — we're on Node 24) with `supertest` as the only new dev dependency.

Tests run against a dedicated `balance_tracker_test` database that `npm test` creates and resets automatically. `test/helpers/setup.js` pins `DATABASE_URL` and all secrets to test values **before** `server.js` loads, and refuses to run if the DB name doesn't contain "test" — so the suite can never read or write real financial data, and never calls Plaid or the exchange-rate API.

## Security coverage (43 tests total)

- All 17 protected `/api` endpoints return 401 without a session; HTML pages redirect to login
- Login: missing fields rejected, identical responses for unknown-user vs wrong-password (no user enumeration), SQL injection payloads cleanly rejected, rate limiting trips after 5 attempts per IP
- Sessions: cookie is HttpOnly with an expiry, logout actually destroys the session, forged session cookies are rejected
- Helmet headers (CSP, nosniff, frame protection) present; malformed account ids rejected

## Data accuracy coverage

- `/api/summary`: exact liquid-cash math (CAD + USD×rate − credit card debt), change vs previous snapshot date
- Retirement accounts excluded from liquid totals; `/api/retirement_summary` USD conversion and per-type grouping
- `/api/trend_data`: carry-forward fills every calendar day with the last known balance; weekly granularity returns Sundays + today; inactive accounts excluded; bogus granularity falls back to daily
- Manual accounts: validation, credit card balances stored negative, liability sign inversion on refresh, one-snapshot-per-day upsert

## Test plan

- [x] `npm test` — 43/43 pass locally (~2s) against Postgres 17

## Follow-ups (noted in CLAUDE.md backlog)

- Mock Plaid client to test the Plaid refresh path and `ITEM_LOGIN_REQUIRED` handling
- Playwright browser tests for the dashboard UI
- Run the suite in CI (GitHub Actions + Postgres service container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)