### PR TITLE
Run npm test in CI on PRs and before deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,48 @@ jobs:
       - name: Run npm audit
         run: npm audit --audit-level=high
 
+  test:
+    name: npm test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # Used by psql/createdb in scripts/setup-test-db.sh (pretest hook)
+      PGHOST: localhost
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/balance_tracker_test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test
+
   deploy-sandbox:
     name: Deploy to sandbox
-    needs: [audit]
+    needs: [audit, test]
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: sandbox
@@ -81,7 +120,7 @@ jobs:
 
   deploy-prd:
     name: Deploy to prd
-    needs: [audit]
+    needs: [audit, test]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: prd

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,7 @@ Requires `.env` with: `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV`, `DATABASE_
 - No UI exists yet for adding a manual (non-Plaid) retirement account. Currently requires using `npm run db:add-snapshot` directly. A form on `connect.html` or a dedicated page should include: account name, institution, account type (401k/IRA/RRSP/etc.), currency (CAD/USD), and category toggle (Liquid/Retirement).
 
 **Tests:**
-- Integration test suite exists in `test/` (security + data accuracy, run via `npm test`). Remaining priorities:
+- Integration test suite exists in `test/` (security + data accuracy, run via `npm test`). CI runs the suite on every PR and before every deploy (`.github/workflows/deploy.yml` `test` job, Postgres 17 service container). Remaining priorities:
   - Unit tests for retirement subtype auto-classification (`RETIREMENT_SUBTYPES` in server.js) — requires extracting the logic or mocking Plaid's token exchange
   - Plaid refresh flow (`refreshBalances` Plaid path) with a mocked Plaid client, including `ITEM_LOGIN_REQUIRED` handling
   - Browser/UI tests with Playwright (login flow, dashboard renders totals, granularity toggle)
-  - Run tests in CI on PRs (GitHub Actions + Postgres service container)


### PR DESCRIPTION
## Summary
- Adds a `test` job to the Deploy workflow that runs the full integration suite (`npm test`) on every PR, push to main, and tag
- Uses a `postgres:17-alpine` service container (same major version as docker-compose) with health checks
- The existing `pretest` hook (`scripts/setup-test-db.sh`) works unchanged: `psql`/`createdb` connect via `PGHOST`/`PGUSER`/`PGPASSWORD`, and tests point at `balance_tracker_test` via `TEST_DATABASE_URL`
- Both `Deploy to sandbox` and `Deploy to prd` now require the test job to pass in addition to npm audit, so a failing suite blocks deploys as well as merges
- Updates the CLAUDE.md test backlog to mark this item done

## Test plan
- [ ] `npm test` job on this PR goes green (this PR exercises the new job itself)
- [x] YAML validated locally
- [x] Full suite passes locally (43 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)