### PR TITLE
Remove stale migration-010 backlog entry from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,6 @@ Requires `.env` with: `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV`, `DATABASE_
 
 ## Backlog
 
-**Pending promotion to production:**
-- Run `node migrations/010_add_account_category.js` against the production DB before or immediately after deploying the retirement feature. The migration is idempotent and safe to re-run.
-
 **Manual retirement account form:**
 - No UI exists yet for adding a manual (non-Plaid) retirement account. Currently requires using `npm run db:add-snapshot` directly. A form on `connect.html` or a dedicated page should include: account name, institution, account type (401k/IRA/RRSP/etc.), currency (CAD/USD), and category toggle (Liquid/Retirement).
 


### PR DESCRIPTION
Migration `010_add_account_category.js` was verified applied to production on 2026-07-16 — an idempotent re-run against the prod DB reported the column, constraint, and index all already present and no accounts needing correction. The "Pending promotion to production" backlog entry is therefore stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)