### PR TITLE
Add pause/resume for Plaid sync (manual updates for broken institutions)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Monolithic Node.js (Express 5) app with vanilla JS frontend. Single `server.js` 
 - Liabilities/credit cards stored as negative balances
 - `accounts.is_active` used for soft-delete
 - `accounts.plaid_account_id` is NULL for manual (non-Plaid) accounts
+- `plaid_items.sync_paused` pauses Plaid refresh for an item (e.g. broken bank MFA); its accounts are treated as manually-updated until resumed (toggled from connect.html via `POST /api/set_sync_paused`)
 
 **Key business logic:**
 - `/api/trend_data` uses SQL WITH clauses to generate a complete daily date series with carry-forward for missing balances, then aggregates by granularity (daily/weekly/monthly)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Monolithic Node.js (Express 5) app with vanilla JS frontend. Single `server.js` 
 - Liabilities/credit cards stored as negative balances
 - `accounts.is_active` used for soft-delete
 - `accounts.plaid_account_id` is NULL for manual (non-Plaid) accounts
-- `plaid_items.sync_paused` pauses Plaid refresh for an item (e.g. broken bank MFA); its accounts are treated as manually-updated until resumed (toggled from connect.html via `POST /api/set_sync_paused`)
+- `plaid_items.sync_paused` pauses Plaid refresh for an item (e.g. broken bank MFA); its accounts are treated as manually-updated until resumed (toggled from connect.html via `POST /api/set_sync_paused`); each pause/resume transition is recorded in `sync_events`
 
 **Key business logic:**
 - `/api/trend_data` uses SQL WITH clauses to generate a complete daily date series with carry-forward for missing balances, then aggregates by granularity (daily/weekly/monthly)

--- a/db/add_sync_paused.sql
+++ b/db/add_sync_paused.sql
@@ -7,3 +7,15 @@
 
 ALTER TABLE plaid_items
   ADD COLUMN IF NOT EXISTS sync_paused BOOLEAN NOT NULL DEFAULT false;
+
+-- Audit trail of pause/resume transitions, so it's always possible to tell
+-- when an institution was paused and which stretches of balance history were
+-- manually entered vs Plaid-synced.
+CREATE TABLE IF NOT EXISTS sync_events (
+  id SERIAL PRIMARY KEY,
+  plaid_item_id INTEGER REFERENCES plaid_items(id),
+  action VARCHAR(10) NOT NULL,  -- 'paused' | 'resumed'
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_events_item ON sync_events(plaid_item_id);

--- a/db/add_sync_paused.sql
+++ b/db/add_sync_paused.sql
@@ -1,0 +1,9 @@
+-- Adds plaid_items.sync_paused: when true, the item is skipped during Plaid
+-- balance refreshes and its accounts are treated as manually-updated instead.
+-- Used when an institution's Plaid connection is broken (e.g. unsupported MFA)
+-- and balances must be entered by hand until the connection works again.
+--
+-- Apply with: psql -d balance_tracker -f db/add_sync_paused.sql
+
+ALTER TABLE plaid_items
+  ADD COLUMN IF NOT EXISTS sync_paused BOOLEAN NOT NULL DEFAULT false;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -34,6 +34,7 @@ CREATE TABLE plaid_items (
   plaid_item_id VARCHAR(100) UNIQUE,
   access_token_encrypted BYTEA,  -- Encrypted access token
   login_required BOOLEAN NOT NULL DEFAULT false,
+  sync_paused BOOLEAN NOT NULL DEFAULT false,  -- Skip Plaid refresh; accounts updated manually
   created_at TIMESTAMP DEFAULT NOW()
 );
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,6 +1,7 @@
 -- Drop existing tables if they exist (for clean start)
 DROP TABLE IF EXISTS balance_snapshots CASCADE;
 DROP TABLE IF EXISTS accounts CASCADE;
+DROP TABLE IF EXISTS sync_events CASCADE;
 DROP TABLE IF EXISTS plaid_items CASCADE;
 DROP TABLE IF EXISTS exchange_rates CASCADE;
 DROP TABLE IF EXISTS users CASCADE;
@@ -35,6 +36,14 @@ CREATE TABLE plaid_items (
   access_token_encrypted BYTEA,  -- Encrypted access token
   login_required BOOLEAN NOT NULL DEFAULT false,
   sync_paused BOOLEAN NOT NULL DEFAULT false,  -- Skip Plaid refresh; accounts updated manually
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Table: sync_events (audit trail of pause/resume transitions per item)
+CREATE TABLE sync_events (
+  id SERIAL PRIMARY KEY,
+  plaid_item_id INTEGER REFERENCES plaid_items(id),
+  action VARCHAR(10) NOT NULL,  -- 'paused' | 'resumed'
   created_at TIMESTAMP DEFAULT NOW()
 );
 
@@ -81,6 +90,7 @@ CREATE INDEX idx_balance_snapshots_account_date ON balance_snapshots(account_id,
 CREATE INDEX idx_accounts_institution ON accounts(institution_name);
 CREATE INDEX idx_accounts_active ON accounts(is_active);
 CREATE INDEX idx_accounts_category ON accounts(account_category);
+CREATE INDEX idx_sync_events_item ON sync_events(plaid_item_id);
 CREATE INDEX idx_exchange_rates_currencies ON exchange_rates(from_currency, to_currency);
 
 -- Helper functions for encrypting/decrypting access tokens

--- a/public/connect.html
+++ b/public/connect.html
@@ -207,6 +207,33 @@
             white-space: nowrap;
         }
 
+        .sync-paused-badge {
+            background: #e8eaf6;
+            border: 1px solid #667eea;
+            color: #3f51b5;
+            font-size: 0.78rem;
+            font-weight: 600;
+            padding: 3px 8px;
+            border-radius: 4px;
+            white-space: nowrap;
+        }
+
+        .sync-toggle-button {
+            background: transparent;
+            color: #667eea;
+            border: 1px solid #667eea;
+            padding: 5px 13px;
+            border-radius: 6px;
+            font-size: 0.82rem;
+            font-weight: 600;
+            cursor: pointer;
+            width: auto;
+            transition: background 0.2s, color 0.2s;
+        }
+
+        .sync-toggle-button:hover { background: #667eea; color: white; }
+        .sync-toggle-button:disabled { background: #ccc; border-color: #ccc; color: white; cursor: not-allowed; }
+
         /* ── Account rows inside an institution ──────────────────────────── */
         .institution-accounts {
             border-top: 1px solid #e0e0e0;

--- a/public/js/connect.js
+++ b/public/js/connect.js
@@ -40,12 +40,16 @@ function renderPlaidInstitutions(accounts) {
                 plaid_item_id:  acc.plaid_item_id || null,
                 login_required: false,
                 sync_paused:    false,
+                sync_paused_at: null,
                 accounts: [],
             });
         }
         const g = groups.get(acc.institution_name);
         if (acc.login_required) g.login_required = true;
-        if (acc.sync_paused) g.sync_paused = true;
+        if (acc.sync_paused) {
+            g.sync_paused = true;
+            g.sync_paused_at = acc.sync_paused_at || null;
+        }
         g.accounts.push(acc);
     });
 
@@ -72,6 +76,7 @@ function renderManualAccounts(accounts) {
                 plaid_item_id:  null,
                 login_required: false,
                 sync_paused:    false,
+                sync_paused_at: null,
                 accounts: [],
             });
         }
@@ -110,7 +115,10 @@ function buildInstitutionGroup(institutionName, info) {
     // syncing resumes.
     let badgeHtml;
     if (info.sync_paused) {
-        badgeHtml = '<span class="sync-paused-badge">Sync paused — manual updates</span>';
+        const since = info.sync_paused_at
+            ? ` since ${new Date(info.sync_paused_at).toLocaleDateString('en-CA', { month: 'short', day: 'numeric', year: 'numeric' })}`
+            : '';
+        badgeHtml = `<span class="sync-paused-badge">Sync paused${since} — manual updates</span>`;
     } else if (info.login_required) {
         badgeHtml = '<span class="login-required-badge">Login required</span>';
     } else {

--- a/public/js/connect.js
+++ b/public/js/connect.js
@@ -116,9 +116,9 @@ function buildInstitutionGroup(institutionName, info) {
     let badgeHtml;
     if (info.sync_paused) {
         const since = info.sync_paused_at
-            ? ` since ${new Date(info.sync_paused_at).toLocaleDateString('en-CA', { month: 'short', day: 'numeric', year: 'numeric' })}`
+            ? ` since ${new Date(info.sync_paused_at).toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: '2-digit' })}`
             : '';
-        badgeHtml = `<span class="sync-paused-badge">Sync paused${since} — manual updates</span>`;
+        badgeHtml = `<span class="sync-paused-badge">Paused${since} - manual updates</span>`;
     } else if (info.login_required) {
         badgeHtml = '<span class="login-required-badge">Login required</span>';
     } else {

--- a/public/js/connect.js
+++ b/public/js/connect.js
@@ -39,11 +39,13 @@ function renderPlaidInstitutions(accounts) {
             groups.set(acc.institution_name, {
                 plaid_item_id:  acc.plaid_item_id || null,
                 login_required: false,
+                sync_paused:    false,
                 accounts: [],
             });
         }
         const g = groups.get(acc.institution_name);
         if (acc.login_required) g.login_required = true;
+        if (acc.sync_paused) g.sync_paused = true;
         g.accounts.push(acc);
     });
 
@@ -69,6 +71,7 @@ function renderManualAccounts(accounts) {
             groups.set(acc.institution_name, {
                 plaid_item_id:  null,
                 login_required: false,
+                sync_paused:    false,
                 accounts: [],
             });
         }
@@ -102,26 +105,42 @@ function buildInstitutionGroup(institutionName, info) {
     const countLabel = `${info.accounts.length} account${info.accounts.length !== 1 ? 's' : ''}`;
     const chevronId  = `chevron-${institutionName.replace(/\s+/g, '-')}`;
 
+    // Badge priority: paused > login required > account count.
+    // While paused, the fix button is hidden — re-auth only matters once
+    // syncing resumes.
+    let badgeHtml;
+    if (info.sync_paused) {
+        badgeHtml = '<span class="sync-paused-badge">Sync paused — manual updates</span>';
+    } else if (info.login_required) {
+        badgeHtml = '<span class="login-required-badge">Login required</span>';
+    } else {
+        badgeHtml = `<span class="account-count-badge">${countLabel}</span>`;
+    }
+
     header.innerHTML = `
         <div class="institution-header-left">
             <span class="institution-name">${institutionName}</span>
         </div>
         <div class="institution-header-right">
-            ${info.login_required
-                ? '<span class="login-required-badge">Login required</span>'
-                : `<span class="account-count-badge">${countLabel}</span>`}
-            ${info.login_required && info.plaid_item_id
+            ${badgeHtml}
+            ${info.login_required && !info.sync_paused && info.plaid_item_id
                 ? `<button class="fix-button"
                        data-item-id="${info.plaid_item_id}"
                        data-institution="${institutionName}">Fix connection</button>`
+                : ''}
+            ${info.plaid_item_id
+                ? `<button class="sync-toggle-button"
+                       data-item-id="${info.plaid_item_id}"
+                       data-paused="${info.sync_paused}">${info.sync_paused ? 'Resume sync' : 'Pause sync'}</button>`
                 : ''}
             <span class="chevron" id="${chevronId}">▼</span>
         </div>
     `;
 
-    // Toggle expansion on header click (but not on the fix button)
+    // Toggle expansion on header click (but not on the buttons)
     header.addEventListener('click', e => {
         if (e.target.classList.contains('fix-button')) return;
+        if (e.target.classList.contains('sync-toggle-button')) return;
         const body    = group.querySelector('.institution-accounts');
         const chevron = group.querySelector('.chevron');
         const isOpen  = !body.classList.contains('collapsed');
@@ -134,6 +153,14 @@ function buildInstitutionGroup(institutionName, info) {
     if (fixBtn) {
         fixBtn.addEventListener('click', () => {
             initializePlaidUpdateMode(fixBtn.dataset.itemId, fixBtn.dataset.institution, fixBtn);
+        });
+    }
+
+    // ── Pause/resume sync button handler ─────────────────────────────────
+    const syncBtn = header.querySelector('.sync-toggle-button');
+    if (syncBtn) {
+        syncBtn.addEventListener('click', () => {
+            toggleSyncPaused(syncBtn.dataset.itemId, syncBtn.dataset.paused !== 'true', syncBtn);
         });
     }
 
@@ -178,6 +205,34 @@ function buildAccountRow(acc) {
     `;
 
     return row;
+}
+
+// ─── Pause/resume Plaid sync ───────────────────────────────────────────────
+
+async function toggleSyncPaused(plaidItemId, pause, btn) {
+    const confirmMsg = pause
+        ? 'Pause Plaid syncing for this institution? Its accounts will be updated manually via the Refresh flow until you resume.'
+        : 'Resume Plaid syncing for this institution? Its accounts will be updated automatically again.';
+    if (!confirm(confirmMsg)) return;
+
+    btn.disabled = true;
+
+    try {
+        const response = await fetch('/api/set_sync_paused', {
+            method:  'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body:    JSON.stringify({ plaid_item_id: plaidItemId, sync_paused: pause }),
+        });
+
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.error || 'Failed to update sync setting');
+
+        loadConnectedBanks();
+    } catch (error) {
+        console.error('Error toggling sync:', error);
+        alert('Error: ' + error.message);
+        btn.disabled = false;
+    }
 }
 
 // ─── Plaid update mode ─────────────────────────────────────────────────────

--- a/server.js
+++ b/server.js
@@ -369,7 +369,12 @@ app.get('/api/accounts', async (req, res) => {
         (a.plaid_account_id IS NOT NULL) AS is_plaid_connected,
         pi.plaid_item_id,
         COALESCE(pi.login_required, false) AS login_required,
-        COALESCE(pi.sync_paused, false) AS sync_paused
+        COALESCE(pi.sync_paused, false) AS sync_paused,
+        (
+          SELECT MAX(se.created_at)
+          FROM sync_events se
+          WHERE se.plaid_item_id = pi.id AND se.action = 'paused'
+        ) AS sync_paused_at
       FROM accounts a
       LEFT JOIN plaid_items pi ON a.plaid_item_id = pi.id
       ORDER BY a.institution_name, a.account_name
@@ -1231,20 +1236,37 @@ app.post('/api/set_sync_paused', async (req, res) => {
     return res.status(400).json({ error: 'plaid_item_id and sync_paused (boolean) are required' });
   }
 
+  const client = await pool.connect();
   try {
-    const result = await pool.query(
-      'UPDATE plaid_items SET sync_paused = $2 WHERE plaid_item_id = $1 RETURNING id',
+    await client.query('BEGIN');
+
+    const result = await client.query(
+      'UPDATE plaid_items SET sync_paused = $2 WHERE plaid_item_id = $1 RETURNING id, institution_name',
       [plaid_item_id, sync_paused]
     );
 
     if (result.rows.length === 0) {
+      await client.query('ROLLBACK');
       return res.status(404).json({ error: 'Item not found' });
     }
 
+    // Audit trail — lets us answer "when was this paused / which balance
+    // history was manual?" long after the fact
+    await client.query(
+      'INSERT INTO sync_events (plaid_item_id, action) VALUES ($1, $2)',
+      [result.rows[0].id, sync_paused ? 'paused' : 'resumed']
+    );
+
+    await client.query('COMMIT');
+
+    console.log(`🔁 Plaid sync ${sync_paused ? 'paused' : 'resumed'} for ${result.rows[0].institution_name} (item ${plaid_item_id})`);
     res.json({ success: true, sync_paused });
   } catch (error) {
+    await client.query('ROLLBACK');
     console.error('Error setting sync_paused:', error);
     res.status(500).json({ error: 'Failed to update sync setting' });
+  } finally {
+    client.release();
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -368,7 +368,8 @@ app.get('/api/accounts', async (req, res) => {
         a.is_active,
         (a.plaid_account_id IS NOT NULL) AS is_plaid_connected,
         pi.plaid_item_id,
-        COALESCE(pi.login_required, false) AS login_required
+        COALESCE(pi.login_required, false) AS login_required,
+        COALESCE(pi.sync_paused, false) AS sync_paused
       FROM accounts a
       LEFT JOIN plaid_items pi ON a.plaid_item_id = pi.id
       ORDER BY a.institution_name, a.account_name
@@ -381,7 +382,8 @@ app.get('/api/accounts', async (req, res) => {
   }
 });
 
-// Get manual accounts (accounts without plaid_account_id) with their last balances.
+// Get manually-updated accounts with their last balances: accounts with no
+// Plaid connection, plus Plaid accounts whose item has sync_paused set.
 // Accepts optional ?category=retirement (or 'liquid') to filter by account_category.
 app.get('/api/manual_accounts', async (req, res) => {
   try {
@@ -409,7 +411,8 @@ app.get('/api/manual_accounts', async (req, res) => {
           LIMIT 1
         ) as last_balance
       FROM accounts a
-      WHERE a.plaid_account_id IS NULL
+      LEFT JOIN plaid_items pi ON a.plaid_item_id = pi.id
+      WHERE (a.plaid_account_id IS NULL OR pi.sync_paused = true)
         AND a.is_active = true
         ${categoryFilter}
       ORDER BY a.institution_name, a.account_name
@@ -1219,6 +1222,32 @@ app.post('/api/clear_item_error', async (req, res) => {
   }
 });
 
+// Pause or resume Plaid syncing for an item. While paused, the item is
+// skipped during balance refreshes and its accounts appear in the manual
+// update flow instead. The access token is kept so syncing can resume later.
+app.post('/api/set_sync_paused', async (req, res) => {
+  const { plaid_item_id, sync_paused } = req.body;
+  if (!plaid_item_id || typeof sync_paused !== 'boolean') {
+    return res.status(400).json({ error: 'plaid_item_id and sync_paused (boolean) are required' });
+  }
+
+  try {
+    const result = await pool.query(
+      'UPDATE plaid_items SET sync_paused = $2 WHERE plaid_item_id = $1 RETURNING id',
+      [plaid_item_id, sync_paused]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'Item not found' });
+    }
+
+    res.json({ success: true, sync_paused });
+  } catch (error) {
+    console.error('Error setting sync_paused:', error);
+    res.status(500).json({ error: 'Failed to update sync setting' });
+  }
+});
+
 // Exchange public token for access token and save to database
 app.post('/api/exchange_public_token', async (req, res) => {
   const { public_token } = req.body;
@@ -1372,6 +1401,7 @@ async function refreshBalances({ manualBalances = {}, date = null, category = nu
         SELECT id, plaid_item_id, access_token_encrypted
         FROM plaid_items
         WHERE access_token_encrypted IS NOT NULL
+          AND sync_paused = false
       `);
 
       console.log(`\n🔄 Refreshing balances for ${itemsResult.rows.length} Plaid items...`);
@@ -1551,6 +1581,7 @@ app.listen(PORT, () => {
   console.log('   GET  /api/summary - Calculated summary');
   console.log('   GET  /api/trend_data - Data for trend chart');
   console.log('   GET  /api/account_history/:id - Individual account history');
+  console.log('   POST /api/set_sync_paused - Pause/resume Plaid syncing for an item');
   console.log('   POST /api/refresh_balances - Update from Plaid and manual accounts\n');
   console.log('📄 Pages:');
   console.log('   http://localhost:3000 - Main Dashboard');

--- a/test/helpers/db.js
+++ b/test/helpers/db.js
@@ -46,16 +46,33 @@ async function seedAccount(pool, {
   isLiability = false,
   isActive = true,
   plaidAccountId = null,
+  plaidItemId = null,
 }) {
   const result = await pool.query(
     `INSERT INTO accounts
        (institution_name, account_name, account_type, account_category,
-        currency, is_liability, is_active, plaid_account_id)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        currency, is_liability, is_active, plaid_account_id, plaid_item_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
      RETURNING id`,
-    [institution, name, type, category, currency, isLiability, isActive, plaidAccountId]
+    [institution, name, type, category, currency, isLiability, isActive, plaidAccountId, plaidItemId]
   );
   return result.rows[0].id;
+}
+
+// Seeds a plaid_items row (no access token, so refreshBalances never calls
+// Plaid for it). Returns { id, plaidItemId } — id is the FK for accounts.
+async function seedPlaidItem(pool, {
+  institution = 'Test Bank',
+  plaidItemId = 'test-item-1',
+  syncPaused = false,
+} = {}) {
+  const result = await pool.query(
+    `INSERT INTO plaid_items (institution_name, plaid_item_id, sync_paused)
+     VALUES ($1, $2, $3)
+     RETURNING id`,
+    [institution, plaidItemId, syncPaused]
+  );
+  return { id: result.rows[0].id, plaidItemId };
 }
 
 async function seedSnapshot(pool, accountId, balance, date, rate = 1.35) {
@@ -81,6 +98,7 @@ module.exports = {
   seedUser,
   seedExchangeRate,
   seedAccount,
+  seedPlaidItem,
   seedSnapshot,
   daysAgo,
 };

--- a/test/helpers/db.js
+++ b/test/helpers/db.js
@@ -12,7 +12,7 @@ function createPool() {
 
 async function truncateAll(pool) {
   await pool.query(`
-    TRUNCATE balance_snapshots, accounts, plaid_items, exchange_rates, users, session
+    TRUNCATE balance_snapshots, accounts, sync_events, plaid_items, exchange_rates, users, session
     RESTART IDENTITY CASCADE
   `);
 }

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -44,6 +44,7 @@ describe('unauthenticated access is blocked', () => {
     '/api/create_link_token',
     '/api/create_link_token_update',
     '/api/clear_item_error',
+    '/api/set_sync_paused',
     '/api/exchange_public_token',
   ];
 

--- a/test/sync-pause.test.js
+++ b/test/sync-pause.test.js
@@ -86,6 +86,7 @@ describe('pausing Plaid sync for an item', () => {
     const chequing = res.body.find(a => a.id === plaidAccount);
     assert.equal(chequing.sync_paused, true);
     assert.equal(chequing.is_plaid_connected, true);
+    assert.ok(chequing.sync_paused_at, 'sync_paused_at should be set while paused');
   });
 
   it('paused accounts respect the category filter', async () => {
@@ -116,6 +117,14 @@ describe('pausing Plaid sync for an item', () => {
 
     const res = await agent.get('/api/manual_accounts');
     assert.deepEqual(res.body.map(a => a.account_name), ['RRSP']);
+  });
+
+  it('records an audit event for each pause/resume transition', async () => {
+    const events = await pool.query(
+      'SELECT action FROM sync_events WHERE plaid_item_id = $1 ORDER BY id',
+      [item.id]
+    );
+    assert.deepEqual(events.rows.map(e => e.action), ['paused', 'resumed']);
   });
 
   it('rejects bad input and unknown items', async () => {

--- a/test/sync-pause.test.js
+++ b/test/sync-pause.test.js
@@ -1,0 +1,135 @@
+// Sync pause tests: pausing a Plaid item routes its accounts into the manual
+// update flow (and back), without touching the Plaid linkage.
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const { app } = require('./helpers/setup');
+const db = require('./helpers/db');
+
+const pool = db.createPool();
+const RATE = 1.35;
+
+after(async () => {
+  await pool.end();
+});
+
+describe('pausing Plaid sync for an item', () => {
+  let agent;
+  let item;
+  let plaidAccount;
+  let manualAccount;
+
+  before(async () => {
+    await db.truncateAll(pool);
+    await db.seedUser(pool);
+    await db.seedExchangeRate(pool, RATE);
+
+    agent = request.agent(app);
+    const login = await agent
+      .post('/api/login')
+      .set('X-Forwarded-For', '10.10.0.3')
+      .send(db.TEST_USER);
+    assert.equal(login.status, 200, 'test login failed');
+
+    // A Plaid-linked institution with one account, plus a pure manual account
+    item = await db.seedPlaidItem(pool, {
+      institution: 'Broken Bank',
+      plaidItemId: 'item-broken-bank',
+    });
+    plaidAccount = await db.seedAccount(pool, {
+      institution: 'Broken Bank',
+      name: 'Chequing',
+      plaidAccountId: 'plaid-acc-1',
+      plaidItemId: item.id,
+    });
+    manualAccount = await db.seedAccount(pool, {
+      institution: 'Manual Bank',
+      name: 'RRSP',
+      type: 'rrsp',
+      category: 'retirement',
+    });
+    await db.seedSnapshot(pool, plaidAccount, 1000, db.daysAgo(1), RATE);
+  });
+
+  it('excludes Plaid-linked accounts from manual_accounts by default', async () => {
+    const res = await agent.get('/api/manual_accounts');
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body.map(a => a.account_name), ['RRSP']);
+  });
+
+  it('reports sync_paused=false on /api/accounts', async () => {
+    const res = await agent.get('/api/accounts');
+    const chequing = res.body.find(a => a.id === plaidAccount);
+    assert.equal(chequing.sync_paused, false);
+    assert.equal(chequing.is_plaid_connected, true);
+  });
+
+  it('pausing moves the item accounts into manual_accounts', async () => {
+    const toggle = await agent
+      .post('/api/set_sync_paused')
+      .send({ plaid_item_id: item.plaidItemId, sync_paused: true });
+    assert.equal(toggle.status, 200);
+    assert.equal(toggle.body.sync_paused, true);
+
+    const res = await agent.get('/api/manual_accounts');
+    const names = res.body.map(a => a.account_name).sort();
+    assert.deepEqual(names, ['Chequing', 'RRSP']);
+
+    // Last balance is carried into the manual update flow
+    const chequing = res.body.find(a => a.account_name === 'Chequing');
+    assert.equal(parseFloat(chequing.last_balance), 1000);
+  });
+
+  it('paused state is exposed on /api/accounts, linkage intact', async () => {
+    const res = await agent.get('/api/accounts');
+    const chequing = res.body.find(a => a.id === plaidAccount);
+    assert.equal(chequing.sync_paused, true);
+    assert.equal(chequing.is_plaid_connected, true);
+  });
+
+  it('paused accounts respect the category filter', async () => {
+    const res = await agent.get('/api/manual_accounts?category=retirement');
+    assert.deepEqual(res.body.map(a => a.account_name), ['RRSP']);
+  });
+
+  it('manual balance entry works for a paused account', async () => {
+    const today = db.daysAgo(0);
+    const res = await agent
+      .post('/api/refresh_balances')
+      .send({ manualBalances: { [plaidAccount]: 1250 }, date: today });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.manualAccountsUpdated, 1);
+
+    const latest = await pool.query(
+      'SELECT balance FROM balance_snapshots WHERE account_id = $1 AND date = $2',
+      [plaidAccount, today]
+    );
+    assert.equal(parseFloat(latest.rows[0].balance), 1250);
+  });
+
+  it('resuming removes the accounts from manual_accounts again', async () => {
+    const toggle = await agent
+      .post('/api/set_sync_paused')
+      .send({ plaid_item_id: item.plaidItemId, sync_paused: false });
+    assert.equal(toggle.status, 200);
+
+    const res = await agent.get('/api/manual_accounts');
+    assert.deepEqual(res.body.map(a => a.account_name), ['RRSP']);
+  });
+
+  it('rejects bad input and unknown items', async () => {
+    const missing = await agent.post('/api/set_sync_paused').send({});
+    assert.equal(missing.status, 400);
+
+    const notBoolean = await agent
+      .post('/api/set_sync_paused')
+      .send({ plaid_item_id: item.plaidItemId, sync_paused: 'yes' });
+    assert.equal(notBoolean.status, 400);
+
+    const unknown = await agent
+      .post('/api/set_sync_paused')
+      .send({ plaid_item_id: 'no-such-item', sync_paused: true });
+    assert.equal(unknown.status, 404);
+  });
+});


### PR DESCRIPTION
## Why

One institution's Plaid sync is broken (bank rolled out MFA in a way Plaid doesn't support) and may stay broken indefinitely. Its accounts need manual balance updates for now — but the connection should be able to resume seamlessly if Plaid ever fixes it.

## What

Adds `plaid_items.sync_paused`. While paused:

- **Refresh** — `refreshBalances` skips the item entirely (`WHERE ... AND sync_paused = false`). The encrypted access token is untouched, so nothing needs re-linking to resume.
- **Manual entry** — `/api/manual_accounts` now returns accounts with no Plaid link **or** a paused item, so the existing refresh-modal manual entry flow picks the paused accounts up automatically (prefilled with last known balance).
- **UI** — connect page shows a "Sync paused since &lt;date&gt; — manual updates" badge per institution plus a Pause/Resume sync toggle (with confirm dialog). New `POST /api/set_sync_paused` endpoint, behind the existing session auth.
- **Audit trail** — every pause/resume transition is recorded in the new `sync_events` table (same transaction as the flag update), so it's always possible to tell when an institution was paused and which stretches of balance history were manual. Also logged to the server console.
- **Resuming** — flips the flag; if the item then reports `ITEM_LOGIN_REQUIRED`, the existing "Fix connection" Link update-mode flow takes over. Balance history is continuous either way since both paths upsert into `balance_snapshots (account_id, date)`.

## Deploy note

⚠️ Requires a one-time migration on prod before/with deploy:

```sh
psql "$DATABASE_URL" -f db/add_sync_paused.sql
```

(Idempotent — adds `plaid_items.sync_paused` and the `sync_events` table.) The test DB and fresh installs get both via `db/schema.sql`.

## Testing

- `test/sync-pause.test.js` (9 tests): pause moves accounts into `/api/manual_accounts` and back, `sync_paused`/`sync_paused_at` exposed on `/api/accounts` with linkage intact, category filter, manual balance entry for a paused account, audit events recorded, input validation/404s.
- `/api/set_sync_paused` added to the security suite's protected-endpoint list.
- Full suite: **53/53 passing** locally.
- UI verified manually in local Docker (pause/resume round trips against a Plaid-connected test institution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)